### PR TITLE
Fix regex to capture more Amazon TLDs

### DIFF
--- a/URLClean.js
+++ b/URLClean.js
@@ -18,7 +18,7 @@
 // @include     https://www.target.com/*
 // @include     https://www.linkedin.com/*
 // @include     https://www.etsy.com/*
-// @include     /^https:\/\/[a-z]+\.amazon\.(?:[a-z]{2,3}|[a-z]{2}\.[a-z]{2})\/.*$/
+// @include     /^https:\/\/[a-z]+\.amazon\.(?:[a-z]{2,3}|[a-z]{2,3}\.[a-z]{2})\/.*$/
 // @exclude     https://www.amazon.com/gp/buy/*
 // @include     /^https?:\/\/[a-z]+\.google\.(?:[a-z]{2,3}|[a-z]{2}\.[a-z]{2})\/.*$/
 // @include     /^https:\/\/[a-z.]+\.ebay(desc)?(\.[a-z]{2,3})?\.[a-z]{2,}\/.*$/
@@ -49,7 +49,7 @@
   const currSearch = location.search;
 
   const ebay = /^[a-z.]+\.ebay(desc)?(\.[a-z]{2,3})?\.[a-z]{2,}$/;
-  const amazon = /^[a-z]+\.amazon\.(?:[a-z]{2,3}|[a-z]{2}\.[a-z]{2})$/;
+  const amazon = /^[a-z]+\.amazon\.(?:[a-z]{2,3}|[a-z]{2,3}\.[a-z]{2})$/;
   const google = /^[a-z]+\.google\.(?:[a-z]{2,3}|[a-z]{2}\.[a-z]{2})(\.[a-z]{2,})?$/i;
   const target = /^[a-z]+\.target\.com?(\.[a-z]{2,3})?$/;
   const bing = /^[a-z]+\.bing\.(?:[a-z]{2,3}|[a-z]{2}\.[a-z]{2})$/;


### PR DESCRIPTION
Tweaked regex in `@include` and `const amazon` to capture additional Amazon TLDs.
See: https://github.com/dividedby/General-URL-Cleaner-Revived/issues/12

Tested using the following URLs, which would now all be cleaned successfully after this commit, but previously some wouldn't:

```
// Amazon US
https://www.amazon.com/Bulletproof-Ketogenic-Friendly-Responsibly-Coconuts/dp/B00R7FFYO8/?_encoding=UTF8&pd_rd_w=gYmjE&content-id=amzn1.sym.0e739659-7c9d-4d82-868c-90015618ffcc&pf_rd_p=0e739659-7c9d-4d82-868c-90015618ffcc&pf_rd_r=Q5AC3GCV7WW0GS64WVHH&pd_rd_wg=Hqnx8&pd_rd_r=0dd0c997-0d17-4e6f-bc63-97c1513ceb33&ref_=pd_gw_exports_top_sellers_unrec&th=1

// Amazon AU
https://www.amazon.com.au/Abireiv-Cable-Waterproof-Buried-able-Compatible/dp/B09M5XYXHQ/ref=sr_1_1_sspa?crid=18TIC6JJWNTLF&keywords=cable&qid=1703829614&sprefix=cab%2Caps%2C294&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1

// Amazon JP
https://www.amazon.co.jp/-/en/Panasonic-WH4415P-Better-Small-White/dp/B008IDMFEU/?_encoding=UTF8&pd_rd_w=5qVAk&content-id=amzn1.sym.1ff70ab5-f36d-477f-9aa1-2ee545862c19&pf_rd_p=1ff70ab5-f36d-477f-9aa1-2ee545862c19&pf_rd_r=N7ABHTTGYVF9SD209XYT&pd_rd_wg=SIe9J&pd_rd_r=45fa7af7-505c-4634-9c8f-73056dd9a15d&ref_=pd_gw_exports_top_sellers_unrec_jp&th=1

// Amazon SG
https://www.amazon.sg/2-Pack-Bluetooth-Tracker-Water-Resistant-Compatible/dp/B09B2XXBFR?ref_=Oct_DLandingS_D_cc1e5ed0_1&th=1
```