### PR TITLE
chore: add agent config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/gearbox-log.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+## Agent skills
+
+### Issue tracker
+GitHub issues in `dividedby/General-URL-Cleaner-Revived` (via `gh`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+State: `needs-triage`, `ready-for-agent`, `ready-for-human`, `blocked`, `wontfix`. Category: `bug`, `enhancement`, `chore`, `epic`. Size: `size:S/M/L/XL`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+Single-context: root `CONTEXT.md` + `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,16 @@
+# Issue tracker: GitHub
+
+This repo's issues and PRDs live as GitHub issues, managed via the `gh` CLI.
+Generic `gh` mechanics (create/view/list/comment/label/close, repo inference)
+and the shared label vocabulary are the common `dividedby` convention —
+canonical reference: the `skills` repo,
+[`docs/agents/issue-tracker.md`](https://github.com/dividedby/skills/blob/main/docs/agents/issue-tracker.md)
+and [`docs/agents/labels.md`](https://github.com/dividedby/skills/blob/main/docs/agents/labels.md).
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/labels.md
+++ b/docs/agents/labels.md
@@ -1,0 +1,90 @@
+# Label Convention
+
+The canonical source of truth for issue-label **names, colors, and descriptions**
+across all of `dividedby`'s repos.
+
+Labels fall into four tiers plus a remove-stock rule.
+
+## Tiering rule
+
+- **CORE** — every repo carries these.
+- **LOOP/NETWORK** — only repos that run the proposal loops (full-tier repos).
+- **CHANNELS** — owned by `dividedby/skills`; consumer repos *apply* them but never
+  create them.
+
+Domain one-off labels stay **local** and untouched. The convention governs the
+shared vocabulary, not a repo's private labels.
+
+## CORE — State (all repos)
+
+Where the issue sits in the workflow. Combine freely with a category label.
+
+| Label             | Color    | Description                                                       |
+| ----------------- | -------- | ----------------------------------------------------------------- |
+| `needs-triage`    | `FBCA04` | Maintainer needs to evaluate this issue                          |
+| `ready-for-agent` | `0E8A16` | Fully specified, ready for an AFK agent                          |
+| `ready-for-human` | `1D76DB` | Requires human implementation                                    |
+| `blocked`         | `E4820A` | Ready to proceed but waiting on an external dependency or decision |
+| `wontfix`         | `FFFFFF` | Will not be actioned                                             |
+| `idea-inbox`      | `D4C5F9` | The single freeform idea-intake issue for this repo (one per repo) |
+
+## CORE — Category (all repos)
+
+What kind of work it is. Combine freely with a state label.
+
+| Label         | Color    | Description                                              |
+| ------------- | -------- | -------------------------------------------------------- |
+| `bug`         | `D73A4A` | Something is broken                                      |
+| `enhancement` | `84B6EB` | New capability or improvement                            |
+| `chore`       | `BFD4F2` | Maintenance or tooling with no user-facing change        |
+| `epic`        | `7057FF` | Aggregate issue grouping related child issues            |
+
+## CORE — Size (all repos)
+
+Best-effort effort estimate. Applied when filing or triaging an issue.
+
+| Label    | Color    | Description          |
+| -------- | -------- | -------------------- |
+| `size:S` | `E6E6E6` | Small: < 1 day       |
+| `size:M` | `C8C8C8` | Medium: 1–2 days     |
+| `size:L` | `AAAAAA` | Large: 3–5 days      |
+| `size:XL`| `888888` | Extra large: > 1 week |
+
+## LOOP/NETWORK (full-tier repos)
+
+| Label                          | Color    | Description                                                       |
+| ------------------------------ | -------- | ----------------------------------------------------------------- |
+| `workflow-onboarding`          | `0052CC` | Onboarding this repo to a proposal-loop workflow                 |
+| `source:agent-research`        | `5319E7` | Filed by the apply-agent-research loop                           |
+| `source:architecture-review`   | `5319E7` | Filed by the improve-codebase-architecture loop                  |
+| `source:staleness-review`      | `5319E7` | Filed by the staleness-review loop                               |
+
+## CHANNELS (owned by `dividedby/skills`, applied by consumers)
+
+| Label                    | Color    | Description                                                |
+| ------------------------ | -------- | --------------------------------------------------------- |
+| `skill-request`          | `006B75` | Cross-repo demand for a skill (aggregated per ADR 0006)   |
+| `skill-promotion`        | `D93FB3` | Cross-repo offer of a local skill for promotion           |
+| `awaiting-corroboration` | `BFD4F2` | Triaged but parked pending cross-repo corroboration       |
+
+## Issue title convention
+
+With category, state, and size labels covering what the work is, where it sits, and how big it is, issue titles don't need to encode any of that. Keep titles short and descriptive — a plain statement of the thing, not a prefixed summary. Prefer:
+
+> `Fix login redirect after OAuth callback`
+
+over:
+
+> `[bug][S] Fix login redirect after OAuth callback`
+
+The labels do that work. A glanceable title is faster to scan in the issue list.
+
+## Remove stock
+
+Every repo removes these unused GitHub stock defaults on setup:
+
+`documentation`, `duplicate`, `good first issue`, `help wanted`, `invalid`, `question`.
+
+Before deleting, re-label any issue carrying a stock label onto the appropriate
+convention label. Recreate `bug` and `enhancement` with the canonical colors above
+in place of GitHub's defaults.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,38 @@
+# Triage Labels
+
+The skills speak in terms of canonical triage roles. This file maps those roles
+to the actual label strings used in this repo's issue tracker.
+
+## State labels
+
+| Role               | Label             | Meaning                                          |
+| ------------------ | ----------------- | ------------------------------------------------ |
+| Needs evaluation   | `needs-triage`    | Maintainer needs to evaluate this issue          |
+| AFK-ready          | `ready-for-agent` | Fully specified, ready for an AFK agent          |
+| Human required     | `ready-for-human` | Requires human implementation                    |
+| Blocked            | `blocked`         | Waiting on an external dependency or decision    |
+| Won't action       | `wontfix`         | Will not be actioned                             |
+
+## Category labels
+
+| Category    | Label         | Meaning                                           |
+| ----------- | ------------- | ------------------------------------------------- |
+| Bug         | `bug`         | Something is broken                               |
+| Enhancement | `enhancement` | New capability or improvement                     |
+| Chore       | `chore`       | Maintenance or tooling, no user-facing change     |
+| Epic        | `epic`        | Aggregate issue grouping related child issues     |
+
+## Size labels
+
+| Size       | Label     | Meaning              |
+| ---------- | --------- | -------------------- |
+| Small      | `size:S`  | < 1 day              |
+| Medium     | `size:M`  | 1–2 days             |
+| Large      | `size:L`  | 3–5 days             |
+| Extra large| `size:XL` | > 1 week             |
+
+For full label details (colors, tiers, remove-stock rule) see `docs/agents/labels.md`.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
+corresponding label string from this table. Edit state-label rows to match whatever
+vocabulary you actually use in a given repo.


### PR DESCRIPTION
Applies the standard dividedby agent-config convention.

- `CLAUDE.md` — issue-tracker, triage-label, and domain-docs skill refs
- `docs/agents/issue-tracker.md` — canonical seed (verbatim from moodreader)
- `docs/agents/labels.md` — canonical seed (verbatim from moodreader)
- `docs/agents/triage-labels.md` — canonical seed (verbatim from moodreader)
- `docs/agents/domain.md` — generic seed (verbatim from setup-matt-pocock-skills)
- `.gitignore` — ignore `.claude/gearbox-log.jsonl`

GitHub labels: created/recolored 14 CORE labels; deleted 6 stock labels (documentation, duplicate, good first issue, help wanted, invalid, question). No open issues carried stock labels.
