### PR TITLE
ci: Node test gate + CI for URL cleaners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node --test

--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -41,9 +41,11 @@
    * Vars
    */
 
-  const currHost = location.host;
-  const currPath = location.pathname;
-  const currSearch = location.search;
+  const _domAvailable = typeof location !== "undefined" && typeof document !== "undefined";
+
+  const currHost = _domAvailable ? location.host : "";
+  const currPath = _domAvailable ? location.pathname : "";
+  const currSearch = _domAvailable ? location.search : "";
 
   const ebay = /^[a-z.]*\.?ebay(desc)?(\.[a-z]{2,3})?(\.[a-z]+)?$/;
   const amazon = /^[a-z.]*\.?amazon(\.[a-z]{2,3})?(\.[a-z]+)?$/;
@@ -75,147 +77,149 @@
    * Main
    */
 
-  if (bing.test(currHost)) {
-    setCurrUrl(cleanBing(currSearch));
-    cleanLinks(parserAll);
-    return;
-  }
-
-  if (currHost == "www.linkedin.com") {
-    setCurrUrl(cleanLinkedin(currSearch));
-    cleanLinks(parserAll);
-    return;
-  }
-
-  if (currHost == "www.etsy.com") {
-    setCurrUrl(cleanEtsy(currSearch));
-    cleanLinks(parserAll);
-    return;
-  }
-
-  if (currHost == "www.yahoo.com") {
-    setCurrUrl(cleanYahoo(currSearch));
-    cleanLinks(parserAll);
-    return;
-  }
-
-  if (currHost === "www.youtube.com") {
-    if (currPath === "/redirect") {
-      location.href = cleanYoutubeRedir(currSearch);
-    }
-
-    if (currPath === "/watch") {
-      setCurrUrl(cleanYoutube(currSearch));
-    }
-
-    cleanLinks(parserYoutube);
-    return;
-  }
-
-  if (currHost.endsWith(".newegg.com") || currHost.endsWith(".newegg.ca")) {
-    if (currSearch) {
-      setCurrUrl(cleanNewegg(currSearch));
-    }
-
-    cleanLinks(parserNewegg);
-    return;
-  }
-
-  if (currHost === "www.imdb.com") {
-    if (currSearch) {
-      setCurrUrl(cleanImdb(currSearch));
-    }
-
-    cleanLinks(parserIMDB);
-    onhashchange = deleteHash();
-    return;
-  }
-
-  if (google.test(currHost)) {
-    if (currPath === "/url" || currPath === "/imgres") {
-      location.href = cleanGenericRedir(currSearch);
-    }
-
-    if (!currSearch && !/[&#]q=/.test(location.hash)) {
+  if (_domAvailable) {
+    if (bing.test(currHost)) {
+      setCurrUrl(cleanBing(currSearch));
+      cleanLinks(parserAll);
       return;
     }
 
-    setCurrUrl(cleanGoogle(currPath + currSearch));
-    changeState(googleInstant);
-
-    if (currSearch.includes("tbm=isch")) {
-      cleanLinksAlways(parserGoogleImages);
-    } else {
-      cleanLinks(parserGoogle);
+    if (currHost == "www.linkedin.com") {
+      setCurrUrl(cleanLinkedin(currSearch));
+      cleanLinks(parserAll);
+      return;
     }
 
-    return;
-  }
-
-  if (ebay.test(currHost)) {
-    if (currPath.includes("/itm/")) {
-      setCurrUrl(cleanEbayItem(location));
-    } else if (currSearch) {
-      setCurrUrl(cleanEbayParams(currSearch));
+    if (currHost == "www.etsy.com") {
+      setCurrUrl(cleanEtsy(currSearch));
+      cleanLinks(parserAll);
+      return;
     }
 
-    cleanLinks(parserEbay);
-    onhashchange = deleteHash;
-    return;
-  }
-
-  if (target.test(currHost)) {
-    if (currPath.includes("/p/")) {
-      setCurrUrl(cleanTargetItemp(location));
-    } else if (currSearch) {
-      setCurrUrl(cleanTargetParams(currSearch));
+    if (currHost == "www.yahoo.com") {
+      setCurrUrl(cleanYahoo(currSearch));
+      cleanLinks(parserAll);
+      return;
     }
 
-    cleanLinks(parserTarget);
-    onhashchange = deleteHash;
-    return;
-  }
+    if (currHost === "www.youtube.com") {
+      if (currPath === "/redirect") {
+        location.href = cleanYoutubeRedir(currSearch);
+      }
 
-  if (amazon.test(currHost)) {
-    if (currPath.includes("/dp/")) {
-      setCurrUrl(cleanAmazonItemdp(location));
-    } else if (currPath.includes("/gp/product")) {
-      setCurrUrl(cleanAmazonItemgp(location));
-    } else if (currSearch) {
-      setCurrUrl(cleanAmazonParams(currSearch));
+      if (currPath === "/watch") {
+        setCurrUrl(cleanYoutube(currSearch));
+      }
+
+      cleanLinks(parserYoutube);
+      return;
     }
 
-    cleanLinks(parserAmazon);
-    onhashchange = deleteHash();
-    return;
-  }
+    if (currHost.endsWith(".newegg.com") || currHost.endsWith(".newegg.ca")) {
+      if (currSearch) {
+        setCurrUrl(cleanNewegg(currSearch));
+      }
 
-  if (currHost == "twitter.com") {
-    if (currSearch) {
-      setCurrUrl(cleanTwitterParams(currSearch));
+      cleanLinks(parserNewegg);
+      return;
     }
 
-    cleanLinks(parserTwitter);
-    return;
-  }
+    if (currHost === "www.imdb.com") {
+      if (currSearch) {
+        setCurrUrl(cleanImdb(currSearch));
+      }
 
-  if (currHost == "www.facebook.com") {
-    if (currSearch) {
-      setCurrUrl(cleanFacebookParams(currSearch));
+      cleanLinks(parserIMDB);
+      onhashchange = deleteHash();
+      return;
     }
 
-    cleanLinks(parserFacebook);
-    return;
-  }
+    if (google.test(currHost)) {
+      if (currPath === "/url" || currPath === "/imgres") {
+        location.href = cleanGenericRedir(currSearch);
+      }
 
-  if (currHost == "disqus.com") {
-    cleanLinks(parserDisqus);
-    return;
-  }
+      if (!currSearch && !/[&#]q=/.test(location.hash)) {
+        return;
+      }
 
-  if (currHost === "app.getpocket.com") {
-    cleanLinks(parserAll);
-    return;
+      setCurrUrl(cleanGoogle(currPath + currSearch));
+      changeState(googleInstant);
+
+      if (currSearch.includes("tbm=isch")) {
+        cleanLinksAlways(parserGoogleImages);
+      } else {
+        cleanLinks(parserGoogle);
+      }
+
+      return;
+    }
+
+    if (ebay.test(currHost)) {
+      if (currPath.includes("/itm/")) {
+        setCurrUrl(cleanEbayItem(location));
+      } else if (currSearch) {
+        setCurrUrl(cleanEbayParams(currSearch));
+      }
+
+      cleanLinks(parserEbay);
+      onhashchange = deleteHash;
+      return;
+    }
+
+    if (target.test(currHost)) {
+      if (currPath.includes("/p/")) {
+        setCurrUrl(cleanTargetItemp(location));
+      } else if (currSearch) {
+        setCurrUrl(cleanTargetParams(currSearch));
+      }
+
+      cleanLinks(parserTarget);
+      onhashchange = deleteHash;
+      return;
+    }
+
+    if (amazon.test(currHost)) {
+      if (currPath.includes("/dp/")) {
+        setCurrUrl(cleanAmazonItemdp(location));
+      } else if (currPath.includes("/gp/product")) {
+        setCurrUrl(cleanAmazonItemgp(location));
+      } else if (currSearch) {
+        setCurrUrl(cleanAmazonParams(currSearch));
+      }
+
+      cleanLinks(parserAmazon);
+      onhashchange = deleteHash();
+      return;
+    }
+
+    if (currHost == "twitter.com") {
+      if (currSearch) {
+        setCurrUrl(cleanTwitterParams(currSearch));
+      }
+
+      cleanLinks(parserTwitter);
+      return;
+    }
+
+    if (currHost == "www.facebook.com") {
+      if (currSearch) {
+        setCurrUrl(cleanFacebookParams(currSearch));
+      }
+
+      cleanLinks(parserFacebook);
+      return;
+    }
+
+    if (currHost == "disqus.com") {
+      cleanLinks(parserDisqus);
+      return;
+    }
+
+    if (currHost === "app.getpocket.com") {
+      cleanLinks(parserAll);
+      return;
+    }
   }
 
   /*
@@ -626,5 +630,18 @@
     return decodeURIComponent(
       url.replace("https://getpocket.com/redirect?url=", "")
     );
+  }
+
+  // ponytail: Node export + load guard exist only so the pure cleaners are unit-testable; Tampermonkey defines window/document so the guard is a no-op in-browser
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      cleanGoogle, cleanBing, cleanLinkedin, cleanEtsy, cleanYahoo,
+      cleanTwitterParams, cleanYoutube, cleanImdb, cleanNewegg,
+      cleanTargetParams, cleanFacebookParams, cleanAmazonParams,
+      cleanEbayParams, cleanUtm,
+      googleParams, ebayParams, amazonParams, neweggParams, imdbParams,
+      bingParams, youtubeParams, twitterParams, targetParams,
+      facebookParams, linkedinParams, etsyParams, yahooParams,
+    };
   }
 })();

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -1,0 +1,237 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  cleanGoogle,
+  cleanEbayParams,
+  cleanAmazonParams,
+  cleanYahoo,
+  cleanLinkedin,
+  cleanUtm,
+} = require("../URLClean.user.js");
+
+// ---------------------------------------------------------------------------
+// cleanGoogle
+// Strips: ved, sxsrf, ei, uact, source, iflsig, rlz, etc.
+// Keeps:  q, tbm, and other functional params
+// Pattern uses (?:&|^) lookahead logic so the leading ? is preserved via the
+// ?→?& trick and the first & is stripped by the trailing .replace("&","").
+// ---------------------------------------------------------------------------
+describe("cleanGoogle", () => {
+  it("strips ved, sxsrf, ei while keeping q", () => {
+    assert.equal(
+      cleanGoogle("?q=hello&ved=abc&sxsrf=xyz&ei=123"),
+      "?q=hello"
+    );
+  });
+
+  it("strips source and uact while keeping q", () => {
+    assert.equal(
+      cleanGoogle("?q=test&source=hp&uact=5"),
+      "?q=test"
+    );
+  });
+
+  it("passes through a bare q with no tracking params", () => {
+    assert.equal(cleanGoogle("?q=cats"), "?q=cats");
+  });
+
+  it("strips multiple tracking params, keeps q and tbm", () => {
+    assert.equal(
+      cleanGoogle("?q=shoes&tbm=shop&ved=2ahUK&sxsrf=AB1cd&ei=xyz"),
+      "?q=shoes&tbm=shop"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanEbayParams
+// Strips: _sacat, _odkw, _from, _trksid, rt  (matched by ebayParams regex)
+// Keeps:  _nkw, LH_BIN, and other search/filter params
+// The regex uses a lookahead (?=&|$) so it does NOT consume the trailing &;
+// adjacent functional params therefore keep their & separator.
+// ---------------------------------------------------------------------------
+describe("cleanEbayParams", () => {
+  it("strips _sacat, _from, rt while keeping _nkw and LH_BIN", () => {
+    assert.equal(
+      cleanEbayParams("?_nkw=shoes&_sacat=0&_from=R40&rt=nc&LH_BIN=1"),
+      "?_nkw=shoes&LH_BIN=1"
+    );
+  });
+
+  it("strips _sacat while keeping _nkw and LH_BIN", () => {
+    assert.equal(
+      cleanEbayParams("?_nkw=laptop&_sacat=177&LH_BIN=1"),
+      "?_nkw=laptop&LH_BIN=1"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanEbayParams("?_nkw=keyboard&LH_Auction=1"),
+      "?_nkw=keyboard&LH_Auction=1"
+    );
+  });
+
+  it("returns ? when only tracking params are present", () => {
+    assert.equal(cleanEbayParams("?_sacat=0&_from=R40"), "?");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanAmazonParams
+// Strips: ref, crid, sprefix, encoding, th, pf_rd_*, pd_rd_*, etc.
+// Keeps:  keywords, k, i, s, and other functional search params
+//
+// KNOWN BEHAVIOR: the ($|&) group in amazonParams CONSUMES the trailing &
+// when a stripped param is not at the end of the string, causing the
+// following param to lose its & separator (they are joined without &).
+// These tests encode that actual current behavior.
+// ---------------------------------------------------------------------------
+describe("cleanAmazonParams", () => {
+  it("strips ref while keeping k", () => {
+    assert.equal(
+      cleanAmazonParams("?k=headphones&ref=nb_sb_noss_2"),
+      "?k=headphones"
+    );
+  });
+
+  it("strips ref and crid; trailing & consumed merges i into keywords", () => {
+    // "keywords=laptop" + "ref=..." stripped (consumes &) + "crid=..." stripped (consumes &) + "i=electronics"
+    // After first strip: ?&keywords=laptopi=electronics (& between crid and i was consumed)
+    assert.equal(
+      cleanAmazonParams(
+        "?keywords=laptop&ref=sr_1_1&crid=ABC123&sprefix=lap%2Caps%2C100&i=electronics"
+      ),
+      "?keywords=laptopi=electronics"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanAmazonParams("?k=monitor&s=electronics"),
+      "?k=monitor&s=electronics"
+    );
+  });
+
+  it("removes trailing ? when all params are stripped", () => {
+    assert.equal(cleanAmazonParams("?ref=sr_1_1"), "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanYahoo
+// Strips: guccounter, guce_referrer, guce_referrer_sig
+// Keeps:  p, fr, and other functional params
+//
+// KNOWN BEHAVIOR: same ($|&)-consuming issue as Amazon — the & before the
+// param following a stripped one is eaten, merging param names together.
+// ---------------------------------------------------------------------------
+describe("cleanYahoo", () => {
+  it("strips guccounter; following guce_referrer param loses & separator", () => {
+    // ?p=news&guccounter=1&guce_referrer=abc&guce_referrer_sig=xyz
+    // After ?→?&:  ?&p=news&guccounter=1&guce_referrer=abc&guce_referrer_sig=xyz
+    // Strip &guccounter=1& -> consumes trailing & -> guce_referrer joins p=news directly
+    // Strip &guce_referrer_sig=xyz (end) -> gone
+    // Result after .replace("&",""): ?p=newsguce_referrer=abc
+    assert.equal(
+      cleanYahoo("?p=news&guccounter=1&guce_referrer=abc&guce_referrer_sig=xyz"),
+      "?p=newsguce_referrer=abc"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(cleanYahoo("?p=finance&fr=yfp-t"), "?p=finance&fr=yfp-t");
+  });
+
+  it("strips lone guccounter", () => {
+    assert.equal(cleanYahoo("?p=news&guccounter=2"), "?p=news");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanLinkedin
+// Strips: eBP, refId, trackingId, trk, flagship3_search_srp_jobs, lipi, lici
+// Keeps:  keywords, location, and other functional params
+//
+// KNOWN BEHAVIOR: same ($|&)-consuming issue — stripped mid-string params
+// eat the & before the next param.
+// ---------------------------------------------------------------------------
+describe("cleanLinkedin", () => {
+  it("strips trk at the start of the query, keeps keywords", () => {
+    // trk at first position: ?trk=abc&keywords=engineer
+    // After ?→?&: ?&trk=abc&keywords=engineer
+    // &trk=abc& matched, & consumed -> ?keywords=engineer after .replace("&","")
+    assert.equal(
+      cleanLinkedin("?trk=abc&keywords=engineer"),
+      "?keywords=engineer"
+    );
+  });
+
+  it("strips trk and refId at the end; adjacent param loses & separator", () => {
+    // ?keywords=engineer&location=Austin&trk=abc&refId=xyz
+    // &trk=abc& consumed -> ?&keywords=engineer&location=AustinrefId=xyz (& before refId eaten)
+    // &refId=xyz at end stripped
+    // After .replace("&",""): ?keywords=engineer&location=AustinrefId=xyz
+    assert.equal(
+      cleanLinkedin("?keywords=engineer&location=Austin&trk=abc&refId=xyz"),
+      "?keywords=engineer&location=AustinrefId=xyz"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanLinkedin("?keywords=developer&location=Remote"),
+      "?keywords=developer&location=Remote"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanUtm
+// Strips: params starting with utm_  (utm_source, utm_medium, utm_campaign…)
+// Keeps:  all other params
+//
+// NOTE: the loop starts at index 1 (i -= 1 before first check), so the FIRST
+// param is never inspected — a utm_ param in position [0] survives. This is a
+// known behavior quirk encoded here for regression coverage.
+// ---------------------------------------------------------------------------
+describe("cleanUtm", () => {
+  it("strips utm_source and utm_medium from the middle/end", () => {
+    assert.equal(
+      cleanUtm("https://example.com/page?ref=home&utm_source=email&utm_medium=cpc"),
+      "https://example.com/page?ref=home"
+    );
+  });
+
+  it("strips utm_campaign and utm_content while keeping non-utm params", () => {
+    assert.equal(
+      cleanUtm("https://example.com/page?id=456&utm_campaign=summer&name=test"),
+      "https://example.com/page?id=456&name=test"
+    );
+  });
+
+  it("leaves URLs with no query string unchanged", () => {
+    assert.equal(
+      cleanUtm("https://example.com/page"),
+      "https://example.com/page"
+    );
+  });
+
+  it("leaves URLs with only non-utm params unchanged", () => {
+    assert.equal(
+      cleanUtm("https://example.com/?id=1&name=foo"),
+      "https://example.com/?id=1&name=foo"
+    );
+  });
+
+  it("utm_ in position [0] (first param) survives due to loop-start-at-1 behavior", () => {
+    // Known quirk: loop does i-=1 before first test, so pars[0] is never checked
+    assert.equal(
+      cleanUtm("https://example.com/?utm_source=email&id=1"),
+      "https://example.com/?utm_source=email&id=1"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Node test gate so URL-cleaning changes have an automated check (none existed: no `package.json`, no CI).
- Make the pure cleaners in `URLClean.user.js` testable under Node via a load-time DOM guard (`_domAvailable`) + a `module.exports` seam at the end of the IIFE. No cleaning logic or regex changed — in-browser behavior is identical (Tampermonkey defines `window`/`document`, so the guard is a no-op there).
- Add `test/cleaners.test.js` (stdlib `node:test`/`node:assert`, zero deps) covering the active sites + regression: Google, eBay, Amazon, Yahoo, LinkedIn, UTM.
- Add `.github/workflows/test.yml` running `node --test` on push + PR.

## Test plan
- [x] `node --test` → 23/23 pass
- [x] `node -e "require('./URLClean.user.js')"` exits 0 (no DOM crash)
- [x] Diff confirms only the load guard + export block changed in `URLClean.user.js`; no regex/logic touched
- [ ] CI workflow green on this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
