### PR TITLE
fix: stop stripping Google authuser (breaks account switching)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -66,7 +66,7 @@
   const targetParams = /&(lnk|tref|searchTermRaw)(=[^&#]*)?($|&)/g;
   const facebookParams = /&(set)(=[^&#]*)?($|&)/g;
   const googleParams =
-    /(?:&|^)(uact|iflsig|sxsrf|ved|source(id)?|s?ei|tab|tbo|h[ls]|authuser|n?um|ie|aqs|as_qdr|bav|bi[wh]|bs|bvm|cad|channel|complete|cp|s?client|d[pc]r|e(ch|msg|s_sm)|g(fe|ws)_rd|gpsrc|noj|btnG|o[eq]|p(si|bx|f|q)|rct|rlz|site|spell|tbas|usg|xhr|gs_[a-z]+)(=[^&#]*)?(?=$|&)/g;
+    /(?:&|^)(uact|iflsig|sxsrf|ved|source(id)?|s?ei|tab|tbo|h[ls]|n?um|ie|aqs|as_qdr|bav|bi[wh]|bs|bvm|cad|channel|complete|cp|s?client|d[pc]r|e(ch|msg|s_sm)|g(fe|ws)_rd|gpsrc|noj|btnG|o[eq]|p(si|bx|f|q)|rct|rlz|site|spell|tbas|usg|xhr|gs_[a-z]+)(=[^&#]*)?(?=$|&)/g;
   const linkedinParams =
     /&(eBP|refId|trackingId|trk|flagship3_search_srp_jobs|lipi|lici)(=[^&#]*)?($|&)/g;
   const etsyParams =

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -44,6 +44,18 @@ describe("cleanGoogle", () => {
       "?q=shoes&tbm=shop"
     );
   });
+
+  it("retains authuser (functional) while stripping ved (tracking)", () => {
+    // authuser selects the signed-in Google account and must not be stripped.
+    // Input:  ?q=hello&authuser=1&ved=abc
+    // After ?→?&:  ?&q=hello&authuser=1&ved=abc
+    // &ved=abc matched at end (lookahead $) → stripped
+    // After .replace("&","") removes first &: ?q=hello&authuser=1
+    assert.equal(
+      cleanGoogle("?q=hello&authuser=1&ved=abc"),
+      "?q=hello&authuser=1"
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop stripping Google's `authuser` query param — it is functional (selects the signed-in account), not tracking. Stripping it broke multi-account switching (reported on GreasyFork, almahmud 2025-08-08).
- Only `authuser` was removed from the `googleParams` regex; all other Google tracking params are unchanged.

## Test plan
- [x] `node --test` → 24/24 pass
- [x] New regression test: `cleanGoogle` retains `authuser=1`, still strips `ved`
- [ ] Browser: confirm account switching at google.com with the script enabled (manual, post-merge)

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
