### PR TITLE
test: lock in eBay _sop preservation (issue #28 not reproducible)

### DIFF
--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -90,6 +90,18 @@ describe("cleanEbayParams", () => {
   it("returns ? when only tracking params are present", () => {
     assert.equal(cleanEbayParams("?_sacat=0&_from=R40"), "?");
   });
+
+  it("retains _sop (sort-order) while stripping _trksid (tracking)", () => {
+    // _sop is eBay's functional sort param and must never be stripped.
+    // _trksid matches _(trksid) in ebayParams and is removed.
+    // Input:  ?_nkw=foo&_sop=15&_trksid=abc
+    // _trksid matched at end (lookahead $) → stripped via lookahead, leaving no trailing &
+    // Result: ?_nkw=foo&_sop=15
+    assert.equal(
+      cleanEbayParams("?_nkw=foo&_sop=15&_trksid=abc"),
+      "?_nkw=foo&_sop=15"
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Investigated the report that eBay `_sop` (sort-order) is stripped, breaking sort-by-price. **Not reproducible on current code** — `ebayParams` matches `_(o?sacat|odkw|from|trksid)` and `rt`, none of which match `_sop`. `cleanEbayParams("?_nkw=foo&_sop=15&_trksid=abc")` returns `?_nkw=foo&_sop=15`.
- No logic change. Adds a regression test that locks in `_sop` preservation while confirming tracking params (`_trksid`) are still stripped, so this can't regress silently.

## Test plan
- [x] `node --test` → 25/25 pass
- [x] New test: `cleanEbayParams` retains `_sop=15`, strips `_trksid`

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
