### PR TITLE
feat: add Audible tracking-param cleaning

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -19,6 +19,7 @@
 // @include     https://www.etsy.com/*
 // @include     https://www.yahoo.com/*
 // @include     /^https:\/\/[a-z0-9.]*\.?amazon(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
+// @include     /^https:\/\/[a-z0-9.]*\.?audible(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?google(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?ebay(desc)?(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*twitter.com\/.*$/
@@ -190,6 +191,16 @@
 
       cleanLinks(parserAmazon);
       onhashchange = deleteHash();
+      return;
+    }
+
+    if (/^[a-z0-9.]*\.?audible(\.[a-z0-9]{2,3})?(\.[a-z]+)?$/.test(currHost)) {
+      // ponytail: param-strip only; product-path rewrite deferred pending live Audible URL verification
+      if (currSearch) {
+        setCurrUrl(cleanAmazonParams(currSearch));
+      }
+
+      cleanLinks(parserAll);
       return;
     }
 

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -146,6 +146,35 @@ describe("cleanAmazonParams", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cleanAmazonParams (Audible)
+// Audible shares Amazon's tracking-param structure; the dispatch branch reuses
+// cleanAmazonParams directly, so these cases prove the shared cleaner works on
+// Audible-style query strings.
+// Strips: ref, pf_rd_*  (matched by amazonParams)
+// Keeps:  node and other functional params
+// ---------------------------------------------------------------------------
+describe("cleanAmazonParams (Audible tracking params)", () => {
+  it("strips ref and pf_rd_r while keeping node", () => {
+    // ?ref=foo&pf_rd_r=bar&node=123
+    // After ?→?&: ?&ref=foo&pf_rd_r=bar&node=123
+    // &ref=foo& matched → stripped (trailing & consumed) → ?&pf_rd_r=bar&node=123
+    // &pf_rd_r=bar& matched → stripped (trailing & consumed) → ?&node=123
+    // .replace("&","") removes first &: ?node=123
+    assert.equal(
+      cleanAmazonParams("?ref=foo&pf_rd_r=bar&node=123"),
+      "?node=123"
+    );
+  });
+
+  it("strips ref alone from an Audible-style query string", () => {
+    assert.equal(
+      cleanAmazonParams("?node=123&ref=nb_sb_noss"),
+      "?node=123"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cleanYahoo
 // Strips: guccounter, guce_referrer, guce_referrer_sig
 // Keeps:  p, fr, and other functional params


### PR DESCRIPTION
## Summary
- Add Audible support (requested on GreasyFork, Meta 2 2024-10-28). Audible is an Amazon property and shares its tracking params.
- New `@include` for Audible domains + a Main-dispatch branch that strips tracking params by reusing `cleanAmazonParams` (the existing `amazonParams` regex) and cleans links via `parserAll`, mirroring the param-only sites. No new regex.
- Product-path (ASIN) rewriting is intentionally deferred (marked with a `ponytail:` comment) — it needs live Audible URL verification.

## Test plan
- [x] `node --test` → 27/27 pass
- [x] New tests: Audible tracking params (`ref`, `pf_rd_*`) stripped, functional param (`node`) kept
- [ ] Browser: confirm on a real audible.com URL that tracking params are removed and product links still work (manual, post-merge)

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
