### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/gearbox-log.jsonl
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` (macOS Finder metadata, was showing as untracked).

## Test plan
- [x] Tooling/docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
