### PR TITLE
fix: wire onhashchange to deleteHash reference on IMDB and Amazon (#35)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -131,7 +131,7 @@
       }
 
       cleanLinks(parserIMDB);
-      onhashchange = deleteHash();
+      onhashchange = deleteHash;
       return;
     }
 
@@ -190,7 +190,7 @@
       }
 
       cleanLinks(parserAmazon);
-      onhashchange = deleteHash();
+      onhashchange = deleteHash;
       return;
     }
 


### PR DESCRIPTION
Lines 134 (IMDB) and 193 (Amazon) assigned `deleteHash()`'s undefined return to `onhashchange`, so the handler was never registered and `deleteHash` ran once at load. Dropped the `()` to match the correct eBay/Target form. All four branches now assign the function reference.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)