### PR TITLE
fix: stop dropping separators when stripping mid-URL tracking params (#30)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -55,24 +55,24 @@
   const bing = /^[a-z.]*\.?bing(\.[a-z]{2,3})?(\.[a-z]+)?$/;
 
   const amazonParams =
-    /&?_?(encoding|crid|sprefix|ref|th|url|ie|pf_rd_[^&#]*?|pd_rd_[^&#]*?|bbn|rw_html_to_wsrp|ref_|content-id)(=[^&#]*)?($|&)/g;
-  const neweggParams = /&(cm_sp|icid|ignorebbr)(=[^&#]*)?($|&)/g;
-  const imdbParams = /&(pf_rd_[a-z]|ref_)(=[^&#]*)?($|&)/g;
+    /&?_?(encoding|crid|sprefix|ref|th|url|ie|pf_rd_[^&#]*?|pd_rd_[^&#]*?|bbn|rw_html_to_wsrp|ref_|content-id)(=[^&#]*)?(?=$|&)/g;
+  const neweggParams = /&(cm_sp|icid|ignorebbr)(=[^&#]*)?(?=$|&)/g;
+  const imdbParams = /&(pf_rd_[a-z]|ref_)(=[^&#]*)?(?=$|&)/g;
   const bingParams =
     /&(redig|toWww|ghpl|lq|ghc|ghsh|ghacc|ghpl|go|qs|form|FORM|filt|pq|s[cpk]|qpvt|cvid)(=[^&#]*)?(?=$|&)/g;
   const youtubeParams =
-    /&(feature|src_vid|annotation_id|[gh]l)(=[^&#]*)?($|&)/g;
+    /&(feature|src_vid|annotation_id|[gh]l)(=[^&#]*)?(?=$|&)/g;
   const ebayParams = /[?&](_(o?sacat|odkw|from|trksid)|rt)(=[^&#]*)?(?=&|$)/g;
-  const twitterParams = /&(src|ref_src|ref_url|vertical|s)(=[^&#]*)?($|&)/g;
-  const targetParams = /&(lnk|tref|searchTermRaw)(=[^&#]*)?($|&)/g;
-  const facebookParams = /&(set)(=[^&#]*)?($|&)/g;
+  const twitterParams = /&(src|ref_src|ref_url|vertical|s)(=[^&#]*)?(?=$|&)/g;
+  const targetParams = /&(lnk|tref|searchTermRaw)(=[^&#]*)?(?=$|&)/g;
+  const facebookParams = /&(set)(=[^&#]*)?(?=$|&)/g;
   const googleParams =
     /(?:&|^)(uact|iflsig|sxsrf|ved|source(id)?|s?ei|tab|tbo|h[ls]|n?um|ie|aqs|as_qdr|bav|bi[wh]|bs|bvm|cad|channel|complete|cp|s?client|d[pc]r|e(ch|msg|s_sm)|g(fe|ws)_rd|gpsrc|noj|btnG|o[eq]|p(si|bx|f|q)|rct|rlz|site|spell|tbas|usg|xhr|gs_[a-z]+)(=[^&#]*)?(?=$|&)/g;
   const linkedinParams =
-    /&(eBP|refId|trackingId|trk|flagship3_search_srp_jobs|lipi|lici)(=[^&#]*)?($|&)/g;
+    /&(eBP|refId|trackingId|trk|flagship3_search_srp_jobs|lipi|lici)(=[^&#]*)?(?=$|&)/g;
   const etsyParams =
-    /&(click_key|click_sum|ref|pro|frs|ga_order|ga_search_type|ga_view_type|ga_search_query|sts|organic_search_click|plkey)(=[^&#]*)?($|&)/g;
-  const yahooParams = /&(guccounter|guce_referrer|guce_referrer_sig)(=[^&#]*)?($|&)/g;
+    /&(click_key|click_sum|ref|pro|frs|ga_order|ga_search_type|ga_view_type|ga_search_query|sts|organic_search_click|plkey)(=[^&#]*)?(?=$|&)/g;
+  const yahooParams = /&(guccounter|guce_referrer|guce_referrer_sig)(=[^&#]*)?(?=$|&)/g;
 
   /*
    * Main

--- a/test/ampersand.test.mjs
+++ b/test/ampersand.test.mjs
@@ -1,0 +1,100 @@
+// Standalone regression test for issue #30.
+// Does NOT import URLClean.user.js (browser globals). Copies fixed regex
+// literals and the clean idiom directly.
+
+import assert from "node:assert/strict";
+
+// --- Fixed regex copies (trailing lookahead, not consuming group) ---
+
+const amazonParams =
+  /&?_?(encoding|crid|sprefix|ref|th|url|ie|pf_rd_[^&#]*?|pd_rd_[^&#]*?|bbn|rw_html_to_wsrp|ref_|content-id)(=[^&#]*)?(?=$|&)/g;
+
+const twitterParams =
+  /&(src|ref_src|ref_url|vertical|s)(=[^&#]*)?(?=$|&)/g;
+
+// --- Cleaning idiom ---
+
+function clean(regex, url) {
+  return url.replace("?", "?&").replace(regex, "").replace("&", "");
+}
+
+// helpers that reset regex lastIndex each call (g flag stateful)
+function cleanAmazon(url) {
+  amazonParams.lastIndex = 0;
+  return clean(amazonParams, url);
+}
+
+function cleanTwitter(url) {
+  twitterParams.lastIndex = 0;
+  return clean(twitterParams, url);
+}
+
+// --- Amazon tests ---
+
+// Tracking param between two kept params: separator must survive.
+assert.equal(
+  cleanAmazon("?k=laptop&ref=nb_sb_noss&node=123"),
+  "?k=laptop&node=123",
+  "Amazon: ref between k and node"
+);
+
+// Tracking param at end: trailing ampersand cleaned.
+assert.equal(
+  cleanAmazon("?k=laptop&ref=nb_sb_noss"),
+  "?k=laptop",
+  "Amazon: ref at end"
+);
+
+// No tracking params: string unchanged.
+assert.equal(
+  cleanAmazon("?k=laptop&node=123"),
+  "?k=laptop&node=123",
+  "Amazon: no tracking params"
+);
+
+// Single tracking param only.
+assert.equal(
+  cleanAmazon("?ref=nb_sb_noss"),
+  "?",
+  "Amazon: only tracking param"
+);
+
+// Multiple consecutive tracking params between kept params.
+assert.equal(
+  cleanAmazon("?k=laptop&ref=nb_sb_noss&crid=ABC&node=123"),
+  "?k=laptop&node=123",
+  "Amazon: two consecutive tracking params between kept params"
+);
+
+// --- Twitter tests ---
+
+// Tracking param (s) removed, other params survive intact — t is not in the
+// regex so it passes through. Core check: no value-gluing from eaten separator.
+assert.equal(
+  cleanTwitter("?s=20&t=abc&foo=bar"),
+  "?t=abc&foo=bar",
+  "Twitter: s removed, t and foo=bar survive without gluing"
+);
+
+// Kept param first, then tracking (s), then another kept.
+assert.equal(
+  cleanTwitter("?foo=bar&s=20&baz=qux"),
+  "?foo=bar&baz=qux",
+  "Twitter: s between two kept params"
+);
+
+// No tracking params.
+assert.equal(
+  cleanTwitter("?foo=bar&baz=qux"),
+  "?foo=bar&baz=qux",
+  "Twitter: no tracking params"
+);
+
+// Single tracking param.
+assert.equal(
+  cleanTwitter("?s=20"),
+  "?",
+  "Twitter: only tracking param"
+);
+
+console.log("All assertions passed.");

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -123,14 +123,13 @@ describe("cleanAmazonParams", () => {
     );
   });
 
-  it("strips ref and crid; trailing & consumed merges i into keywords", () => {
-    // "keywords=laptop" + "ref=..." stripped (consumes &) + "crid=..." stripped (consumes &) + "i=electronics"
-    // After first strip: ?&keywords=laptopi=electronics (& between crid and i was consumed)
+  it("strips ref/crid/sprefix while keeping the separator before i", () => {
+    // ref, crid, sprefix stripped; kept params keywords and i stay joined by &
     assert.equal(
       cleanAmazonParams(
         "?keywords=laptop&ref=sr_1_1&crid=ABC123&sprefix=lap%2Caps%2C100&i=electronics"
       ),
-      "?keywords=laptopi=electronics"
+      "?keywords=laptop&i=electronics"
     );
   });
 
@@ -222,15 +221,11 @@ describe("cleanAudible", () => {
 // param following a stripped one is eaten, merging param names together.
 // ---------------------------------------------------------------------------
 describe("cleanYahoo", () => {
-  it("strips guccounter; following guce_referrer param loses & separator", () => {
-    // ?p=news&guccounter=1&guce_referrer=abc&guce_referrer_sig=xyz
-    // After ?→?&:  ?&p=news&guccounter=1&guce_referrer=abc&guce_referrer_sig=xyz
-    // Strip &guccounter=1& -> consumes trailing & -> guce_referrer joins p=news directly
-    // Strip &guce_referrer_sig=xyz (end) -> gone
-    // Result after .replace("&",""): ?p=newsguce_referrer=abc
+  it("strips guccounter/guce_referrer/guce_referrer_sig, keeping p", () => {
+    // all three guce* params are tracking and removed; kept param p survives
     assert.equal(
       cleanYahoo("?p=news&guccounter=1&guce_referrer=abc&guce_referrer_sig=xyz"),
-      "?p=newsguce_referrer=abc"
+      "?p=news"
     );
   });
 
@@ -262,14 +257,11 @@ describe("cleanLinkedin", () => {
     );
   });
 
-  it("strips trk and refId at the end; adjacent param loses & separator", () => {
-    // ?keywords=engineer&location=Austin&trk=abc&refId=xyz
-    // &trk=abc& consumed -> ?&keywords=engineer&location=AustinrefId=xyz (& before refId eaten)
-    // &refId=xyz at end stripped
-    // After .replace("&",""): ?keywords=engineer&location=AustinrefId=xyz
+  it("strips trk and refId at the end, keeping keywords and location", () => {
+    // trk and refId removed; kept params keywords and location stay joined by &
     assert.equal(
       cleanLinkedin("?keywords=engineer&location=Austin&trk=abc&refId=xyz"),
-      "?keywords=engineer&location=AustinrefId=xyz"
+      "?keywords=engineer&location=Austin"
     );
   });
 


### PR DESCRIPTION
## Problem
Ten per-site param regexes ended with a **consuming** group `($|&)`. The cleaning idiom relies on the trailing separator surviving so the next param stays attached. When a tracking param sat **between two kept params**, the consumed `&` ate the next param's separator and glued values together:

- Amazon: `?k=laptop&ref=nb&node=123` → `?k=laptopnode=123`
- Twitter: the consumed separator left the following tracking param unstripped.

This matches the GreasyFork reports (Amazon 2025-10-11, Twitter 2023-10-30).

## Fix
Convert the trailing `($|&)` to a non-consuming lookahead `(?=$|&)` for: amazonParams, neweggParams, imdbParams, youtubeParams, twitterParams, targetParams, facebookParams, linkedinParams, etsyParams, yahooParams. This matches the already-correct bing/ebay/google regexes. Adds a minimal Node assert-based self-check (`test/ampersand.test.mjs`) covering the mid-URL separator case.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)