### PR TITLE
feat: clean utm_* on all sites by default (opt-out global strip) (#26)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -242,7 +242,9 @@
     // page; opt out via GLOBAL_STRIP.
     if (GLOBAL_STRIP) {
       if (currSearch) {
-        setCurrUrl(cleanUtm(currSearch));
+        // explicit path so an all-utm query is actually cleared from the bar
+        // (replaceState("") would no-op and leave the query in place)
+        setCurrUrl(currPath + cleanUtm(currSearch) + location.hash);
       }
       cleanLinks(parserGlobal);
     }

--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -23,6 +23,7 @@
 // @include     /^https:\/\/[a-z0-9.]*\.?google(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?ebay(desc)?(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*twitter.com\/.*$/
+// @include     *
 // @exclude     /^https:\/\/[a-z0-9.]*\.?amazon(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/(?:gp\/(?:cart|buy|css|legacy|your-account).*|sspa.*)$/
 // @exclude     https://apis.google.com/*
 // @exclude     https://accounts.google.com/*
@@ -43,6 +44,10 @@
    */
 
   const _domAvailable = typeof location !== "undefined" && typeof document !== "undefined";
+
+  // ponytail: opt-out — set false to skip cleaning on sites without a dedicated handler.
+  // Upgrade path: a GM_registerMenuCommand toggle once @grant is added.
+  const GLOBAL_STRIP = true;
 
   const currHost = _domAvailable ? location.host : "";
   const currPath = _domAvailable ? location.pathname : "";
@@ -230,6 +235,16 @@
     if (currHost === "app.getpocket.com") {
       cleanLinks(parserAll);
       return;
+    }
+
+    // ponytail: no dedicated handler for this host — strip generic trackers
+    // everywhere unless the user opted out. Ceiling: one MutationObserver per
+    // page; opt out via GLOBAL_STRIP.
+    if (GLOBAL_STRIP) {
+      if (currSearch) {
+        setCurrUrl(cleanUtm(currSearch));
+      }
+      cleanLinks(parserGlobal);
     }
   }
 
@@ -458,6 +473,16 @@
     }
   }
 
+  function parserGlobal(a) {
+    if (a.search) {
+      a.search = cleanUtm(a.search);
+    }
+    if (a.hash) {
+      a.hash = cleanUtm(a.hash);
+    }
+    a.cleaned = 1;
+  }
+
   function parserTwitter(a) {
     if (a.host !== "t.co") {
       return;
@@ -637,7 +662,7 @@
     if (urlparts.length >= 2) {
       var pars = urlparts[1].split(/[&;]/g);
       //reverse iteration as may be destructive
-      for (var i = pars.length; (i -= 1) > 0; ) {
+      for (var i = pars.length; (i -= 1) >= 0; ) {
         if (/^utm_/.test(pars[i])) {
           pars.splice(i, 1);
         }

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -110,10 +110,8 @@ describe("cleanEbayParams", () => {
 // Strips: ref, crid, sprefix, encoding, th, pf_rd_*, pd_rd_*, etc.
 // Keeps:  keywords, k, i, s, and other functional search params
 //
-// KNOWN BEHAVIOR: the ($|&) group in amazonParams CONSUMES the trailing &
-// when a stripped param is not at the end of the string, causing the
-// following param to lose its & separator (they are joined without &).
-// These tests encode that actual current behavior.
+// amazonParams uses a non-consuming lookahead (?=$|&), so stripping a param in
+// the middle of the string leaves the following param's & separator intact.
 // ---------------------------------------------------------------------------
 describe("cleanAmazonParams", () => {
   it("strips ref while keeping k", () => {

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -285,10 +285,6 @@ describe("cleanLinkedin", () => {
 // cleanUtm
 // Strips: params starting with utm_  (utm_source, utm_medium, utm_campaign…)
 // Keeps:  all other params
-//
-// NOTE: the loop starts at index 1 (i -= 1 before first check), so the FIRST
-// param is never inspected — a utm_ param in position [0] survives. This is a
-// known behavior quirk encoded here for regression coverage.
 // ---------------------------------------------------------------------------
 describe("cleanUtm", () => {
   it("strips utm_source and utm_medium from the middle/end", () => {
@@ -319,11 +315,17 @@ describe("cleanUtm", () => {
     );
   });
 
-  it("utm_ in position [0] (first param) survives due to loop-start-at-1 behavior", () => {
-    // Known quirk: loop does i-=1 before first test, so pars[0] is never checked
+  it("strips utm_ in position [0] (first param)", () => {
     assert.equal(
       cleanUtm("https://example.com/?utm_source=email&id=1"),
-      "https://example.com/?utm_source=email&id=1"
+      "https://example.com/?id=1"
+    );
+  });
+
+  it("collapses to no query string when all params are utm_", () => {
+    assert.equal(
+      cleanUtm("https://example.com/?utm_source=email"),
+      "https://example.com/"
     );
   });
 });


### PR DESCRIPTION
## What
The script was allow-list only — sites without a dedicated handler were never cleaned (GreasyFork feedback: "should clean all sites except excluded ones"). This makes generic `utm_*` stripping the **default** behavior everywhere, with an opt-out.

## How
- `// @include *` so the script runs on all pages (existing `@exclude`s still override it).
- `const GLOBAL_STRIP = true;` near the top — set `false` to opt out. No `@grant` added; the script stays in page scope (avoids the sandbox/`onhashchange` risk a GM menu toggle would carry).
- A fallthrough at the end of dispatch runs **only on hosts with no dedicated handler** (every site branch returns early): cleans the current URL via `cleanUtm` and installs a generic `parserGlobal` link cleaner.
- `parserGlobal` strips `utm_*` from link `search`/`hash` only — no site-specific sub-parsers.

## Also: cleanUtm off-by-one fix
`cleanUtm`'s reverse loop started at index 1, so a `utm_` param in the **first** query position was never stripped. This is load-bearing for the global strip (`?utm_source=...` as the only/first param). Fixed `(i -= 1) > 0` → `(i -= 1) >= 0`; updated the test that pinned the old quirk.

## Scope notes
- Only `utm_*` is stripped globally (the conservative MVP). `parserGlobal` is the extension point for `gclid`/`fbclid`/etc. if wanted later.
- Behavior change: the script now loads on every page for all users (default-on). Tests: `node --test` → 34/34 pass.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)