### PR TITLE
fix: strip Google hyperlink-auditing ping attribute (#16)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -384,6 +384,7 @@
 
   function parserGoogle(a) {
     a.removeAttribute("onmousedown");
+    a.removeAttribute("ping");
     parserAll(a);
   }
 
@@ -395,6 +396,7 @@
     }
 
     a.removeAttribute("onmousedown");
+    a.removeAttribute("ping");
     parserAll(a);
   }
 


### PR DESCRIPTION
## Problem

Issue #16: links "still redirect" on google.com / google.co.uk.

## Root cause (live-verified on current Google)

Drove a live Chrome session on `google.com/search`:

- **0/8** organic result links use the old `/url?q=` redirect — Google fully moved off it; hrefs are now direct destination URLs.
- **8/8** result anchors carry a **`ping` attribute** → `google.com/url` tracker (57/69 anchors page-wide). Clicks beacon through Google's redirect via hyperlink auditing.
- No `onmousedown`, no `jsaction` on organic results.

`parserGoogle`/`parserGoogleImages` stripped `onmousedown`, and `parserAll`'s Google branch only rewrites `/url` and `/imgres` paths — **neither removed `ping`**, so click tracking was unaddressed.

## Fix

Add `a.removeAttribute("ping")` in `parserGoogle` and `parserGoogleImages`, alongside the existing `onmousedown` removal.

## Verification

- Live: applying the strip to result anchors cleared `ping` on **8/8** while hrefs stayed direct (not broken).
- `node --test`: 35 pass, 0 fail.

Scope is Google only, per the issue. The reporter's original `/url?q=` "copy link shows redirect" symptom is stale (Google changed mechanisms since 2025-01); the current tracking vector is `ping`, which this addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
