### PR TITLE
feat: complete cleanAudible functional-param allowlist (#39)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -604,12 +604,19 @@
   }
 
   function cleanAudible(url) {
-    const keep = ["keywords"];
+    // Keep-list derived from a live Audible session (issue #39).
+    const keep = [
+      "keywords", "node", "page", "sort", "publication_date",
+      "audible_programs", "searchNarrator", "searchAuthor",
+    ];
     const parts = url.split("?");
     if (parts.length < 2) return url;
     const kept = parts[1]
       .split(/[&;]/g)
-      .filter((p) => keep.includes(p.split("=")[0]));
+      .filter((p) => {
+        const name = p.split("=")[0];
+        return keep.includes(name) || /_browse-bin$/.test(name);
+      });
     return parts[0] + (kept.length ? "?" + kept.join("&") : "");
   }
 

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -145,7 +145,9 @@ describe("cleanAmazonParams", () => {
 
 // ---------------------------------------------------------------------------
 // cleanAudible
-// Allowlist: keeps ONLY "keywords"; strips everything else.
+// Allowlist: keeps functional nav params (keywords, node, page, sort,
+// publication_date, audible_programs, searchNarrator, searchAuthor) and any
+// param whose name ends with _browse-bin; strips everything else.
 // Returns "" when no allowlisted params remain.
 // ---------------------------------------------------------------------------
 describe("cleanAudible", () => {
@@ -207,6 +209,47 @@ describe("cleanAudible", () => {
 
   it("returns empty string when only non-allowlisted params present", () => {
     assert.equal(cleanAudible("?ref=bar"), "");
+  });
+
+  it("keeps all functional nav params intact (multi-param search/pagination URL)", () => {
+    assert.equal(
+      cleanAudible(
+        "?keywords=mystery&node=18573211011&sort=pubdate-desc-rank&page=2"
+      ),
+      "?keywords=mystery&node=18573211011&sort=pubdate-desc-rank&page=2"
+    );
+  });
+
+  it("keeps a _browse-bin suffixed param and strips tracking params", () => {
+    assert.equal(
+      cleanAudible("?keywords=x&feature_six_browse-bin=123&ref=trackme"),
+      "?keywords=x&feature_six_browse-bin=123"
+    );
+  });
+
+  it("keeps publication_date, audible_programs, searchNarrator, searchAuthor; strips qid and sr", () => {
+    assert.equal(
+      cleanAudible(
+        "?publication_date=last30days&audible_programs=10004&searchNarrator=Weir&searchAuthor=Sanderson&qid=123&sr=1-1"
+      ),
+      "?publication_date=last30days&audible_programs=10004&searchNarrator=Weir&searchAuthor=Sanderson"
+    );
+  });
+
+  it("keeps searchAuthor and strips qid and sr", () => {
+    assert.equal(
+      cleanAudible("?searchAuthor=Sanderson&qid=123&sr=1-1"),
+      "?searchAuthor=Sanderson"
+    );
+  });
+
+  it("keeps multiple _browse-bin variants and strips tracking", () => {
+    assert.equal(
+      cleanAudible(
+        "?feature_ten_browse-bin=1&feature_twenty-two_browse-bin=2&plink=abc"
+      ),
+      "?feature_ten_browse-bin=1&feature_twenty-two_browse-bin=2"
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

Issue #39: `cleanAudible` uses an allowlist and strips every query param not on it, but the keep-list was `["keywords"]` only — inferred, not verified. Any other functional param (pagination/sort/filter) would be silently stripped, breaking navigation.

## Live investigation

Drove a live Chrome session over audible.com (search + category pages, exercising pagination, sort, and filter controls). Observed params, classified:

**Functional (keep):**
| param | role |
|---|---|
| `keywords` | search query |
| `node` | category browse node |
| `page` | pagination |
| `sort` | sort order (`select[name=sort]`: relevancerank, pubdate-desc-rank, price-asc-rank, review-rank, …) |
| `publication_date` | date filter |
| `audible_programs` | program filter (e.g. Plus catalog) |
| `searchNarrator` / `searchAuthor` | narrator/author filters |
| `*_browse-bin` | feature refinement filters — many ordinal names (feature_six/seven/ten/twelve/…); matched by suffix, not hardcoded |

**Tracking (strip):** `ref`, `ref_`, `ref_pageloadid`, `pf_rd_p`, `pf_rd_r`, `plink`, `pageLoadId`, `creativeId`, `qid`, `sr`, `ipRedirectOverride`, and anything else not on the keep-list.

## Fix

Expand the `cleanAudible` keep-list to the confirmed functional names plus a `/_browse-bin$/` suffix match.

## Verification

- Live: `?keywords=mystery&sort=pubdate-desc-rank&page=2` (zero tracking params) loads with the sort select reflecting `pubdate-desc-rank` and pagination intact — functional params work standalone.
- `node --test`: 40 pass, 0 fail (8 pre-existing cleanAudible cases + 5 new covering the multi-param functional URL, `_browse-bin` retention, and qid/sr stripping).

Out of scope (per issue): Audible link cleaning / redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
