### PR TITLE
docs: domain glossary, ADR-0001, and design plan for #48

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,73 @@
+# Context — General URL Cleaner Revived
+
+Domain glossary for the userscript that strips tracking from URLs. This file is a
+glossary only — no implementation details, no specs. When a term here conflicts
+with how code or an issue uses a word, the glossary wins (or the glossary is
+wrong and gets fixed here).
+
+## Glossary
+
+### Tracking parameter
+A URL query parameter that identifies, attributes, or follows a user (e.g. a
+referrer tag, click id, campaign tag) and carries no meaning the destination page
+needs to render correctly. The thing the script exists to remove.
+
+### Functional parameter
+A query parameter the destination page genuinely needs (e.g. a search term, a
+category, a sort order, a page number). Must survive cleaning. The Tracking vs
+Functional distinction is the script's core judgment; an over-broad strip that
+eats a Functional parameter is a defect.
+
+### Cleaning
+Removing Tracking parameters from a URL while preserving its Functional
+parameters and producing a well-formed result (no stray `?`/`&` separators).
+
+### Site
+A web destination the script has dedicated handling for (Google, Amazon, eBay,
+…), selected by a metadata match rule and routed by Site dispatch.
+
+### Parameter registry
+The per-Site collection of patterns naming which query parameters are Tracking
+(to strip) — the data that defines *what* gets removed for each Site.
+
+### Cleaner
+A pure function that takes a URL string and returns the cleaned URL string for
+one Site (or for a cross-cutting concern). Cleaners do not touch the DOM. The
+global `utm_*` strip is a Cleaner. The shared engine behind the per-Site Cleaners
+is `cleanParams(url, registry-pattern)`.
+
+### Redirect decoder
+A pure function that unwraps a redirect/interstitial URL (a link that wraps the
+real destination as an encoded parameter) and returns the real destination, or
+returns the input unchanged when there is nothing to unwrap. Pure, like a
+Cleaner.
+
+### URL transform
+The pure, string-to-string core of link handling for a Site: given a link's URL
+(and any needed siblings), it returns the cleaned URL. Knows nothing about the
+DOM. Exported and unit-tested in Node. This is the testable heart extracted out
+of a Link adapter.
+
+### Link adapter
+The thin DOM-facing half of link handling for a Site. It reads a link's
+attributes (href and click-tracking attributes such as `onmousedown`,
+`jsaction`, `data-expanded-url`), delegates the decision to a URL transform or
+Cleaner, and writes the result back. Holds no URL/parsing logic of its own —
+only attribute I/O. Verified against real pages, not unit-mocked.
+
+### Link cleaning
+Cleaning links *as the page mutates*: a DOM observer watches for added links and
+runs the appropriate Link adapter over them. Distinct from Current-page rewrite,
+which cleans the address bar URL.
+
+### Current-page rewrite
+Replacing the current page's own URL in the address bar with its cleaned form,
+without reloading the page.
+
+### Global strip
+The default-on behavior that applies the `utm_*` Cleaner (and generic Link
+cleaning) on every site, independent of any dedicated Site handler.
+
+### Site dispatch
+The routing step that detects the current Site from the host and selects which
+Cleaners and Link adapters apply.

--- a/docs/adr/0001-pure-url-transform-seam.md
+++ b/docs/adr/0001-pure-url-transform-seam.md
@@ -1,0 +1,47 @@
+# 1. Test through a pure URL-transform seam; verify Link adapters live
+
+Date: 2026-06-14
+
+## Status
+
+Accepted
+
+## Context
+
+The script is a single userscript. Its correctness is the product, but most link
+handling lives in DOM-coupled `parser<Site>()` functions that read and write
+anchor attributes — untestable in Node without a DOM. The pure Cleaners are
+already unit-tested through a `module.exports` seam consumed by a `node:test`
+suite in CI; the parsers are not.
+
+To close that gap we can either:
+
+1. Add a DOM shim (jsdom / linkedom) so the parsers test as-is, or
+2. Split each parser into a pure **URL transform** (string → string, exported,
+   unit-tested) plus a thin **Link adapter** (attribute I/O only), and verify the
+   adapters against real pages via live `--chrome` sessions.
+
+The repo is deliberately zero-dependency: no `package.json`, no bundler, the
+`.user.js` is the deliverable. A DOM shim would be the project's first runtime/dev
+dependency and would let unit tests pass against a fake DOM that may not match real
+site markup — the exact thing that has bitten this script before.
+
+## Decision
+
+Test through a pure URL-transform seam. Extract the string logic out of each
+parser into an exported URL transform tested offline in `node --test`; keep the
+Link adapter as thin attribute I/O verified live with `--chrome`. Do **not** add a
+DOM-shim dependency. Performance is verified the same way — report-only `--chrome`
+profiles, never an automated benchmark in CI.
+
+## Consequences
+
+- The offline test suite stays deterministic, fast, and dependency-free; it covers
+  the logic that actually decides what gets stripped.
+- Real-site behavior is confirmed against real markup, not a shim's approximation —
+  but that confirmation is manual (`--chrome` checklists), so adapter regressions
+  can still slip past CI. The thinness of adapters is what keeps that risk small;
+  any branching logic in an adapter is a smell to push down into the transform.
+- Adding a Site now means: a Parameter registry entry, a Cleaner (via
+  `cleanParams`), and — if links need rewriting — a URL transform + Link adapter.
+- If adapters ever grow logic that can't be made thin, revisit the DOM-shim option.

--- a/docs/design/issue-48-test-harden.md
+++ b/docs/design/issue-48-test-harden.md
@@ -1,0 +1,64 @@
+---
+status: in-progress
+epic: "#48"
+adr: docs/adr/0001-pure-url-transform-seam.md
+---
+
+# Design Plan — Test-harden & refactor URLClean.user.js (#48)
+
+Short-lived implementation scaffolding for epic #48. The issue tracker is
+authoritative for issue bodies; this records the module map, seams, and testing
+strategy. Vocabulary is defined in [CONTEXT.md](../../CONTEXT.md).
+
+## Modules & seams
+
+| Module | Kind | Seam (test entry) | Owns | Must not depend on |
+|--------|------|-------------------|------|--------------------|
+| Parameter registry | data | — | which params are Tracking, per Site | anything |
+| Cleaner engine | pure | `module.exports` → `node --test` | strip Tracking params, preserve Functional, well-formed separators | DOM |
+| Redirect decoder | pure | `module.exports` → `node --test` | unwrap redirect URLs to the real destination | DOM |
+| URL transform | pure | `module.exports` → `node --test` | per-Site link URL cleaning logic | DOM |
+| Link adapter | DOM | live `--chrome` checklist | read/write link attributes, delegate to URL transform/Cleaner | URL/parse logic |
+| Link cleaning / observer | DOM | behavior via transform tests + `--chrome` profile | run adapters over mutating links, bounded cost | — |
+| Metadata & dispatch | config | `--chrome` | `@include`/`@noframes`, host routing | — |
+
+## Core invariant (ADR-0001)
+
+All parse/strip/decode logic lives in the pure modules behind `module.exports` and
+is unit-tested offline. Link adapters are attribute-I/O only and verified live via
+`--chrome`. No DOM-shim dependency; no automated performance benchmark in CI.
+
+## Testing strategy
+
+- **Pure modules (Cleaner engine, Redirect decoder, URL transform):** unit-tested
+  through `module.exports` with `node --test`, offline, asserting on returned
+  strings only — never on regex internals. Characterization-first: pin current
+  behavior before any consolidation, so the refactor is provably behavior-preserving.
+- **Link adapter:** no unit tests. Confirmed against real markup via per-Site
+  `--chrome` checklists. Branching that resists extraction is a smell to push into
+  the URL transform.
+- **Link cleaning / observer:** correctness of *what* gets cleaned is owned by the
+  pure-module tests; this layer is verified for *cost* via report-only `--chrome`
+  before/after profiles.
+- **Refactor gate:** consolidation slices (#57, #58) keep exported signatures as
+  thin aliases so the prior coverage suite stays green with no test edits beyond
+  renames.
+
+## Sequencing
+
+Tracer → core → edge → integration:
+`#49` → {`#51`, `#56`} → {`#52`, `#53`} → {`#57`, `#58`} → {`#54`, `#55`}. `#50`
+(docs) anytime.
+
+## Issue index
+
+- #49 — Remove Twitter / x.com (remove-a-Site deletion; tracer; unblocks #56)
+- #50 — Fix CLAUDE.md "no test framework" claim (docs; design-skipped)
+- #51 — Characterization tests for the 5 redirect decoders
+- #52 — Extract + test URL transforms: Google / Amazon / eBay
+- #53 — Extract + test URL transforms: remaining sites
+- #54 — Observer perf: mark-and-skip in `cleanLinksAlways`
+- #55 — Evaluate/decide `@noframes`
+- #56 — Characterization tests for remaining pure cleaners
+- #57 — Collapse 14 cleaners into `cleanParams(url, regex)`
+- #58 — Merge 5 redirect decoders into one parametrized decoder


### PR DESCRIPTION
## Summary
- Add `CONTEXT.md` — the domain glossary CLAUDE.md referenced but that never existed (Tracking/Functional parameter, Cleaner, Redirect decoder, the URL transform / Link adapter seam, Link cleaning, Global strip, Site dispatch).
- Add `docs/adr/0001-pure-url-transform-seam.md` — record the decision to test through a pure URL-transform seam and verify Link adapters live via `--chrome`, instead of adding a DOM-shim dependency to the zero-dep userscript.
- Add `docs/design/issue-48-test-harden.md` — module map, seams, testing strategy, and issue index for epic #48.

Docs-only; no behavior change. Establishes the vocabulary the #49–#58 backlog issues already reference.

## Test plan
- [ ] Docs render correctly on GitHub (tables, ADR, links).
- [ ] CONTEXT.md stays a glossary — no implementation detail leaked in.
- [ ] Glossary terms match how #49–#58 use them (URL transform / Link adapter).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
