### PR TITLE
chore: remove Twitter / x.com support (#49)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -22,7 +22,6 @@
 // @include     /^https:\/\/[a-z0-9.]*\.?audible(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?google(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?ebay(desc)?(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
-// @include     /^https:\/\/[a-z0-9.]*twitter.com\/.*$/
 // @include     *
 // @exclude     /^https:\/\/[a-z0-9.]*\.?amazon(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/(?:gp\/(?:cart|buy|css|legacy|your-account).*|sspa.*)$/
 // @exclude     https://apis.google.com/*
@@ -68,7 +67,6 @@
   const youtubeParams =
     /&(feature|src_vid|annotation_id|[gh]l)(=[^&#]*)?(?=$|&)/g;
   const ebayParams = /[?&](_(o?sacat|odkw|from|trksid)|rt)(=[^&#]*)?(?=&|$)/g;
-  const twitterParams = /&(src|ref_src|ref_url|vertical|s)(=[^&#]*)?(?=$|&)/g;
   const targetParams = /&(lnk|tref|searchTermRaw)(=[^&#]*)?(?=$|&)/g;
   const facebookParams = /&(set)(=[^&#]*)?(?=$|&)/g;
   const googleParams =
@@ -206,15 +204,6 @@
       }
 
       cleanLinks(parserAll);
-      return;
-    }
-
-    if (currHost == "twitter.com") {
-      if (currSearch) {
-        setCurrUrl(cleanTwitterParams(currSearch));
-      }
-
-      cleanLinks(parserTwitter);
       return;
     }
 
@@ -487,30 +476,6 @@
     a.cleaned = 1;
   }
 
-  function parserTwitter(a) {
-    if (a.host !== "t.co") {
-      return;
-    }
-
-    let fake = "t.co" + a.pathname;
-    let real = a.getAttribute("data-expanded-url");
-    if (real) {
-      a.href = real;
-      a.removeAttribute("data-expanded-url");
-      sessionStorage.setItem(fake, real);
-      return;
-    }
-
-    if (!a.classList.contains("TwitterCard-container")) {
-      return;
-    }
-
-    real = sessionStorage.getItem(fake);
-    if (real) {
-      a.href = real;
-    }
-  }
-
   function parserFacebook(a) {
     let onclick = a.getAttribute("onclick");
     if (!onclick || !onclick.startsWith("LinkshimAsyncLink")) {
@@ -561,10 +526,6 @@
 
   function cleanYahoo(url) {
     return url.replace("?", "?&").replace(yahooParams, "").replace("&", "");
-  }
-
-  function cleanTwitterParams(url) {
-    return url.replace("?", "?&").replace(twitterParams, "").replace("&", "");
   }
 
   function cleanYoutube(url) {
@@ -693,11 +654,11 @@
   if (typeof module !== "undefined" && module.exports) {
     module.exports = {
       cleanGoogle, cleanBing, cleanLinkedin, cleanEtsy, cleanYahoo,
-      cleanTwitterParams, cleanYoutube, cleanImdb, cleanNewegg,
+      cleanYoutube, cleanImdb, cleanNewegg,
       cleanTargetParams, cleanFacebookParams, cleanAmazonParams, cleanAudible,
       cleanEbayParams, cleanUtm,
       googleParams, ebayParams, amazonParams, neweggParams, imdbParams,
-      bingParams, youtubeParams, twitterParams, targetParams,
+      bingParams, youtubeParams, targetParams,
       facebookParams, linkedinParams, etsyParams, yahooParams,
     };
   }

--- a/test/ampersand.test.mjs
+++ b/test/ampersand.test.mjs
@@ -9,9 +9,6 @@ import assert from "node:assert/strict";
 const amazonParams =
   /&?_?(encoding|crid|sprefix|ref|th|url|ie|pf_rd_[^&#]*?|pd_rd_[^&#]*?|bbn|rw_html_to_wsrp|ref_|content-id)(=[^&#]*)?(?=$|&)/g;
 
-const twitterParams =
-  /&(src|ref_src|ref_url|vertical|s)(=[^&#]*)?(?=$|&)/g;
-
 // --- Cleaning idiom ---
 
 function clean(regex, url) {
@@ -22,11 +19,6 @@ function clean(regex, url) {
 function cleanAmazon(url) {
   amazonParams.lastIndex = 0;
   return clean(amazonParams, url);
-}
-
-function cleanTwitter(url) {
-  twitterParams.lastIndex = 0;
-  return clean(twitterParams, url);
 }
 
 // --- Amazon tests ---
@@ -64,37 +56,6 @@ assert.equal(
   cleanAmazon("?k=laptop&ref=nb_sb_noss&crid=ABC&node=123"),
   "?k=laptop&node=123",
   "Amazon: two consecutive tracking params between kept params"
-);
-
-// --- Twitter tests ---
-
-// Tracking param (s) removed, other params survive intact — t is not in the
-// regex so it passes through. Core check: no value-gluing from eaten separator.
-assert.equal(
-  cleanTwitter("?s=20&t=abc&foo=bar"),
-  "?t=abc&foo=bar",
-  "Twitter: s removed, t and foo=bar survive without gluing"
-);
-
-// Kept param first, then tracking (s), then another kept.
-assert.equal(
-  cleanTwitter("?foo=bar&s=20&baz=qux"),
-  "?foo=bar&baz=qux",
-  "Twitter: s between two kept params"
-);
-
-// No tracking params.
-assert.equal(
-  cleanTwitter("?foo=bar&baz=qux"),
-  "?foo=bar&baz=qux",
-  "Twitter: no tracking params"
-);
-
-// Single tracking param.
-assert.equal(
-  cleanTwitter("?s=20"),
-  "?",
-  "Twitter: only tracking param"
 );
 
 console.log("All assertions passed.");


### PR DESCRIPTION
## Summary
- Removes all Twitter / x.com touchpoints: `@include`, `twitterParams`, the `twitter.com` dispatch branch, `cleanTwitterParams()`, `parserTwitter()`, and both `module.exports` entries.
- Drops the Twitter cases from `test/ampersand.test.mjs`. x.com was never matched, so this is a clean removal.
- Tracer-bullet slice for epic #48; unblocks #56.

## Test plan
- [x] `node --test` passes (40 pass / 0 fail)
- [x] `grep -niE 'twitter|x\.com|t\.co' URLClean.user.js` returns no real Twitter refs

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/claude-code)