### PR TITLE
refactor: merge 4 regex redirect decoders into one parametrized decoder (#58)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -613,20 +613,24 @@
     return location.origin + "/itm/" + item;
   }
 
+  function cleanRedir(pattern, url) {
+    return decodeURIComponent(url.match(pattern).pop());
+  }
+
   function cleanYoutubeRedir(url) {
-    return decodeURIComponent(url.match(/[?&]q=([^&]+)/).pop());
+    return cleanRedir(/[?&]q=([^&]+)/, url);
   }
 
   function cleanAmazonRedir(url) {
-    return decodeURIComponent(url.match(/[?&]redirectUrl=([^&]+)/).pop());
+    return cleanRedir(/[?&]redirectUrl=([^&]+)/, url);
   }
 
   function cleanGenericRedir(url) {
-    return decodeURIComponent(url.match(/[?&](new|img)?u(rl)?=([^&]+)/i).pop());
+    return cleanRedir(/[?&](new|img)?u(rl)?=([^&]+)/i, url);
   }
 
   function cleanGenericRedir2(url) {
-    return decodeURIComponent(url.match(/[?&]\w*url=([^&]+)/i).pop());
+    return cleanRedir(/[?&]\w*url=([^&]+)/i, url);
   }
 
   function cleanUtm(url) {


### PR DESCRIPTION
## Summary
- Folds `cleanYoutubeRedir`, `cleanAmazonRedir`, `cleanGenericRedir`, `cleanGenericRedir2` into a single `cleanRedir(pattern, url)`; each per-site name stays as a thin alias passing its wrap-param regex, so dispatch, parsers, and `module.exports` are unaffected.
- `cleanPocketRedir` kept separate — it uses a literal string-prefix replace, not regex capture; folding it would force a two-mode function.
- Behavior-preserving, gated by the #51 characterization suite.

## Test plan
- [x] `node --test` passes (63 pass / 0 fail)
- [x] No test file edited — green suite is the behavior-preservation proof

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/claude-code)