### PR TITLE
refactor: collapse 12 per-site cleaners into cleanParams(url, regex) (#57)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -504,66 +504,56 @@
    * URL string functions
    */
 
+  // Shared separator-fixup idiom: prefix every param with &, delete matched
+  // params, then restore the leading separator. Pass stripTrailingQ=true for
+  // cleaners that should collapse a bare ? to "" when all params are removed.
+  function cleanParams(url, regex, stripTrailingQ) {
+    var result = url.replace("?", "?&").replace(regex, "").replace("&", "");
+    return stripTrailingQ ? result.replace(/\?$/, "") : result;
+  }
+
   function cleanGoogle(url) {
-    return url.replace("?", "?&").replace(googleParams, "").replace("&", "");
+    return cleanParams(url, googleParams);
   }
 
   function cleanBing(url) {
-    return url
-      .replace("?", "?&")
-      .replace(bingParams, "")
-      .replace("&", "")
-      .replace(/\?$/, "");
+    return cleanParams(url, bingParams, true);
   }
 
   function cleanLinkedin(url) {
-    return url.replace("?", "?&").replace(linkedinParams, "").replace("&", "");
+    return cleanParams(url, linkedinParams);
   }
 
   function cleanEtsy(url) {
-    return url.replace("?", "?&").replace(etsyParams, "").replace("&", "");
+    return cleanParams(url, etsyParams);
   }
 
   function cleanYahoo(url) {
-    return url.replace("?", "?&").replace(yahooParams, "").replace("&", "");
+    return cleanParams(url, yahooParams);
   }
 
   function cleanYoutube(url) {
-    return url.replace("?", "?&").replace(youtubeParams, "").replace("&", "");
+    return cleanParams(url, youtubeParams);
   }
 
   function cleanImdb(url) {
-    return url
-      .replace("?", "?&")
-      .replace(imdbParams, "")
-      .replace("&", "")
-      .replace(/\?$/, "");
+    return cleanParams(url, imdbParams, true);
   }
 
   function cleanNewegg(url) {
-    return url.replace("?", "?&").replace(neweggParams, "").replace("&", "");
+    return cleanParams(url, neweggParams);
   }
 
   function cleanTargetParams(url) {
-    return url
-      .replace("?", "?&", "#")
-      .replace(targetParams, "")
-      .replace("&", "");
+    return cleanParams(url, targetParams);
   }
 
   function cleanFacebookParams(url) {
-    return url
-      .replace("?", "?&", "#")
-      .replace(facebookParams, "")
-      .replace("&", "");
+    return cleanParams(url, facebookParams);
   }
 
   function cleanAmazonParams(url) {
-    return url
-      .replace("?", "?&")
-      .replace(amazonParams, "")
-      .replace("&", "")
-      .replace(/\?$/, "");
+    return cleanParams(url, amazonParams, true);
   }
 
   function cleanAudible(url) {
@@ -584,7 +574,7 @@
   }
 
   function cleanEbayParams(url) {
-    return url.replace("?", "?&").replace(ebayParams, "").replace("&", "");
+    return cleanParams(url, ebayParams);
   }
 
   function cleanTargetItemp(a) {


### PR DESCRIPTION
## Summary
- Folds the 12 cleaners sharing the separator-fixup idiom into one `cleanParams(url, regex, stripTrailingQ)`; the flag appends the trailing `.replace(/\?$/,"")` for the collapse-to-`""` variant (`cleanBing`, `cleanImdb`, `cleanAmazonParams`).
- Each per-site name remains a thin delegate (dispatch + `module.exports` unaffected); registry regexes stay compiled once at module scope.
- Left separate by mechanism: `cleanAudible` (allowlist), `cleanUtm` (prefix filter), redirect decoders.
- Behavior-preserving, gated by the full characterization suite.

## Test plan
- [x] `node --test` passes (92 pass / 0 fail)
- [x] No test file edited — green suite is the behavior-preservation proof

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/claude-code)