### PR TITLE
refactor: extract pure transform*Url cores for Google/Amazon/eBay (#52)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -329,12 +329,7 @@
     }
 
     if (google.test(host)) {
-      if (path === "/imgres" || path === "/url") {
-        a.href = cleanGenericRedir(a.search);
-      } else if (a.search) {
-        a.search = cleanGoogle(a.search);
-      }
-
+      a.href = transformGoogleUrl(a.href);
       return;
     }
 
@@ -418,22 +413,7 @@
       return;
     }
 
-    if (a.pathname.includes("black-curtain-redirect.html")) {
-      a.href = cleanAmazonRedir(location);
-    } else if (a.pathname.includes("/dp/")) {
-      a.href = cleanAmazonItemdp(a);
-    } else if (a.pathname.includes("/gp/product")) {
-      a.href = cleanAmazonItemgp(a);
-    } else if (a.pathname.includes("/picassoRedirect")) {
-      a.href = cleanGenericRedir(a.search);
-      a.search = "";
-    } else if (a.search) {
-      a.href = cleanAmazonParams(a.href);
-    }
-
-    if (a.pathname.includes("/ref=")) {
-      a.pathname = cleanAmazonParams(a.pathname);
-    }
+    a.href = transformAmazonUrl(a.href);
   }
 
   function parserEbay(a) {
@@ -441,13 +421,7 @@
       return;
     }
 
-    if (a.pathname.includes("/itm/")) {
-      a.href = cleanEbayItem(a);
-    } else if (a.host.startsWith("pulsar.")) {
-      a.href = cleanEbayPulsar(a.search);
-    } else if (a.search) {
-      a.search = cleanEbayParams(a.search);
-    }
+    a.href = transformEbayUrl(a.href, location.origin);
   }
 
   function parserNewegg(a) {
@@ -598,9 +572,9 @@
     return a.origin + "/itm" + item + origList + a.hash;
   }
 
-  function cleanEbayPulsar(url) {
+  function cleanEbayPulsar(url, origin) {
     let item = url.match(/%7B%22mecs%22%3A%22([0-9]{12})/).pop();
-    return location.origin + "/itm/" + item;
+    return (origin || location.origin) + "/itm/" + item;
   }
 
   function cleanRedir(pattern, url) {
@@ -644,6 +618,58 @@
     );
   }
 
+  function transformGoogleUrl(href) {
+    var u = new URL(href);
+    if (u.pathname === "/imgres" || u.pathname === "/url") {
+      return cleanGenericRedir(u.search);
+    } else if (u.search) {
+      u.search = cleanGoogle(u.search);
+    }
+    return u.href;
+  }
+
+  function transformAmazonUrl(href) {
+    var u = new URL(href);
+    var result = href;
+
+    if (u.pathname.includes("black-curtain-redirect.html")) {
+      result = cleanAmazonRedir(u.search);
+    } else if (u.pathname.includes("/dp/")) {
+      result = cleanAmazonItemdp(u);
+    } else if (u.pathname.includes("/gp/product")) {
+      result = cleanAmazonItemgp(u);
+    } else if (u.pathname.includes("/picassoRedirect")) {
+      var t = new URL(cleanGenericRedir(u.search));
+      t.search = "";
+      result = t.href;
+    } else if (u.search) {
+      result = cleanAmazonParams(href);
+    }
+
+    var u2 = new URL(result);
+    if (u2.pathname.includes("/ref=")) {
+      u2.pathname = cleanAmazonParams(u2.pathname);
+      result = u2.href;
+    }
+
+    return result;
+  }
+
+  function transformEbayUrl(href, pageOrigin) {
+    var u = new URL(href);
+
+    if (u.pathname.includes("/itm/")) {
+      return cleanEbayItem(u);
+    } else if (u.host.startsWith("pulsar.")) {
+      return cleanEbayPulsar(u.search, pageOrigin);
+    } else if (u.search) {
+      u.search = cleanEbayParams(u.search);
+      return u.href;
+    }
+
+    return href;
+  }
+
   // ponytail: Node export + load guard exist only so the pure cleaners are unit-testable; Tampermonkey defines window/document so the guard is a no-op in-browser
   if (typeof module !== "undefined" && module.exports) {
     module.exports = {
@@ -652,6 +678,8 @@
       cleanTargetParams, cleanFacebookParams, cleanAmazonParams, cleanAudible,
       cleanEbayParams, cleanUtm,
       cleanYoutubeRedir, cleanAmazonRedir, cleanGenericRedir, cleanGenericRedir2, cleanPocketRedir,
+      cleanEbayPulsar, cleanEbayItem, cleanAmazonItemdp, cleanAmazonItemgp,
+      transformGoogleUrl, transformAmazonUrl, transformEbayUrl,
       googleParams, ebayParams, amazonParams, neweggParams, imdbParams,
       bingParams, youtubeParams, targetParams,
       facebookParams, linkedinParams, etsyParams, yahooParams,

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -1,0 +1,203 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  transformGoogleUrl,
+  transformAmazonUrl,
+  transformEbayUrl,
+} = require("../URLClean.user.js");
+
+// ---------------------------------------------------------------------------
+// transformGoogleUrl
+// /imgres and /url pathnames → decode via cleanGenericRedir (strips all params)
+// other paths with search → strip tracking params via cleanGoogle
+// clean URL (no tracked params) → returned unchanged
+// ---------------------------------------------------------------------------
+describe("transformGoogleUrl", () => {
+  it("decodes a /url redirect to the target URL", () => {
+    assert.equal(
+      transformGoogleUrl("https://www.google.com/url?url=https%3A%2F%2Fexample.com%2Fpage&sa=t&ved=abc"),
+      "https://example.com/page"
+    );
+  });
+
+  it("decodes a /imgres redirect to the image URL", () => {
+    assert.equal(
+      transformGoogleUrl("https://www.google.com/imgres?imgurl=https%3A%2F%2Fimages.example.com%2Fphoto.jpg&tbnid=xyz"),
+      "https://images.example.com/photo.jpg"
+    );
+  });
+
+  it("strips tracking params from a search URL while keeping q", () => {
+    assert.equal(
+      transformGoogleUrl("https://www.google.com/search?q=hello&ved=abc&sxsrf=xyz"),
+      "https://www.google.com/search?q=hello"
+    );
+  });
+
+  it("passes through a clean search URL unchanged", () => {
+    assert.equal(
+      transformGoogleUrl("https://www.google.com/search?q=cats"),
+      "https://www.google.com/search?q=cats"
+    );
+  });
+
+  it("returns href unchanged when no search params present", () => {
+    assert.equal(
+      transformGoogleUrl("https://www.google.com/"),
+      "https://www.google.com/"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformAmazonUrl
+// /dp/ → strip extra path segments and query, keep ASIN and hash
+// /gp/product → strip extra path, keep ASIN and hash
+// black-curtain-redirect.html → decode redirectUrl from link's own search
+//   (bug fix: original code passed `location` global; now reads from href)
+// /picassoRedirect → decode generic redirect, then blank decoded target's search
+// /ref= in pathname → strip via cleanAmazonParams after chain
+// search params → strip via cleanAmazonParams
+// passthrough → clean URL returned unchanged
+// ---------------------------------------------------------------------------
+describe("transformAmazonUrl", () => {
+  it("canonicalises a /dp/ product URL", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/dp/B07XYZ1234/ref=sr_1_1?keywords=widget&ref=nb_sb_noss"
+      ),
+      "https://www.amazon.com/dp/B07XYZ1234"
+    );
+  });
+
+  it("canonicalises a /dp/ product URL with a hash", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/Product-Name/dp/B00ABCDEFG/ref=sr_1_2?pf_rd_r=XYZ#reviews"
+      ),
+      "https://www.amazon.com/dp/B00ABCDEFG#reviews"
+    );
+  });
+
+  it("canonicalises a /gp/product URL", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/gp/product/B07XYZ1234/ref=ppx_yo_dt_b?ie=UTF8&psc=1"
+      ),
+      "https://www.amazon.com/gp/product/B07XYZ1234"
+    );
+  });
+
+  it("decodes a black-curtain redirect using the link's own search (not page location)", () => {
+    // Bug fix: original parserAmazon passed `location` (page-global) which has
+    // no .match method; correct source is the link's own URL search string.
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/black-curtain-redirect.html?redirectUrl=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB07XYZ1234"
+      ),
+      "https://www.amazon.com/dp/B07XYZ1234"
+    );
+  });
+
+  it("decodes a picassoRedirect and blanks the decoded target's search", () => {
+    // The decoded target URL has its own query string which must be blanked.
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/picassoRedirect?url=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB07XYZ1234%3Fref%3Dabc%26pf_rd_r%3DXYZ"
+      ),
+      "https://www.amazon.com/dp/B07XYZ1234"
+    );
+  });
+
+  it("strips /ref= from the pathname (ref= path check runs after the main chain)", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/SomeProduct/ref=sr_1_1"
+      ),
+      "https://www.amazon.com/SomeProduct/"
+    );
+  });
+
+  it("strips tracked query params from a search URL", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/s?k=headphones&ref=nb_sb_noss_2&crid=ABC"
+      ),
+      "https://www.amazon.com/s?k=headphones"
+    );
+  });
+
+  it("passes through a clean URL unchanged", () => {
+    assert.equal(
+      transformAmazonUrl("https://www.amazon.com/s?k=headphones"),
+      "https://www.amazon.com/s?k=headphones"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformEbayUrl
+// /itm/ → canonicalise via cleanEbayItem (strips extra path/query, keeps orig_cvip)
+// pulsar. host → decode item ID from JSON-encoded search, return canonical /itm/ URL
+//   (bug fix: original cleanEbayPulsar read page-global location.origin; now
+//    accepts explicit pageOrigin arg so it is testable offline)
+// search params → strip via cleanEbayParams
+// clean URL (no /itm/, no pulsar, no tracked params) → returned unchanged
+// ---------------------------------------------------------------------------
+describe("transformEbayUrl", () => {
+  it("canonicalises a /itm/ product URL, stripping extra path segments and query", () => {
+    assert.equal(
+      transformEbayUrl(
+        "https://www.ebay.com/itm/123456789012/s/a?_trksid=p4375.c101&_sacat=0",
+        "https://www.ebay.com"
+      ),
+      "https://www.ebay.com/itm/123456789012"
+    );
+  });
+
+  it("retains orig_cvip param when present in /itm/ URL", () => {
+    // cleanEbayItem preserves orig_cvip (cross-variant item param)
+    assert.equal(
+      transformEbayUrl(
+        "https://www.ebay.com/itm/123456789012?orig_cvip=true&_trksid=abc",
+        "https://www.ebay.com"
+      ),
+      "https://www.ebay.com/itm/123456789012?orig_cvip=true"
+    );
+  });
+
+  it("decodes a pulsar redirect to a canonical /itm/ URL using explicit pageOrigin", () => {
+    // Bug fix: cleanEbayPulsar now accepts origin param instead of using
+    // page-global location.origin, making it testable in Node.
+    assert.equal(
+      transformEbayUrl(
+        "https://pulsar.ebay.com/pulsar?data=%7B%22mecs%22%3A%22123456789012%22%7D",
+        "https://www.ebay.com"
+      ),
+      "https://www.ebay.com/itm/123456789012"
+    );
+  });
+
+  it("strips tracked query params from a search URL", () => {
+    assert.equal(
+      transformEbayUrl(
+        "https://www.ebay.com/sch/i.html?_nkw=shoes&_sacat=0&_from=R40&rt=nc",
+        "https://www.ebay.com"
+      ),
+      "https://www.ebay.com/sch/i.html?_nkw=shoes"
+    );
+  });
+
+  it("passes through a clean URL unchanged", () => {
+    assert.equal(
+      transformEbayUrl(
+        "https://www.ebay.com/sch/i.html?_nkw=keyboard",
+        "https://www.ebay.com"
+      ),
+      "https://www.ebay.com/sch/i.html?_nkw=keyboard"
+    );
+  });
+});


### PR DESCRIPTION
Closes #52.

## What
Extracts the pure URL-transformation core out of the high-traffic parsers (Google, Amazon, eBay) into exported, offline-testable helpers, per ADR-0001, leaving the DOM wrappers as thin attribute I/O.

- `transformGoogleUrl(href)`, `transformAmazonUrl(href)`, `transformEbayUrl(href, pageOrigin)` — all branching/regex internal, return a string, no DOM access.
- `parserAll` (Google branch), `parserAmazon`, `parserEbay` reduced to host-guard + `a.href = transform*(a.href)`.
- `cleanEbayPulsar(url, origin)` made origin-injectable (`origin || location.origin`); browser path unchanged.

## Bug fixes folded in (behavior was broken, not preserved)
- Amazon black-curtain redirect passed the page-global `location` to `cleanAmazonRedir` (a `Location` has no `.match`, so it threw); now decodes from the link's own search.
- eBay pulsar origin is injected rather than read from a global, so it works offline.

## Tests
`test/parsers.test.js` — 18 characterization tests (strip + passthrough per site; black-curtain, picassoRedirect two-step, `/ref=` path strip, `/itm/` orig_cvip retention, pulsar with explicit origin). Full suite: `node --test` → **110 pass, 0 fail**.

## Live --chrome QA (acceptance criterion)
Ran the extracted transforms against real anchor hrefs on live pages:
- **Google** (`/search`): 111 links with params — 0 errors, 0 in-scope tracking params left after clean, `q` preserved 76/76.
- **Google Images** (`udm=2`): 543 links, 0 errors; no `/imgres` links present in the lazy-loaded DOM (that path is covered by the unit test).
- **Amazon** (`/s`): 670 links — `ref=` fully stripped (0 left), 77/78 `/dp/` canonicalized.
- **eBay** (`/sch`): 607 links, 0 errors — tracking fully stripped (0 left), 176/180 `/itm/` canonicalized.

QA surfaced two **pre-existing** cleaner bugs (identical in the original code; out of this PR's behavior-preserving scope) — filed as #66 (Amazon `/dp/product/<ASIN>` throw) and #67 (eBay `/itmnull`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
