### PR TITLE
refactor: extract pure transform*Url cores for remaining parsers (#53)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -323,7 +323,6 @@
 
   function parserAll(a) {
     let host = a.host;
-    let path = a.pathname;
     if (a.cleaned) {
       return;
     }
@@ -334,20 +333,13 @@
     }
 
     if (host === "www.youtube.com") {
-      if (path === "/watch") {
-        a.search = cleanYoutube(a.search);
-      } else if (path === "/redirect") {
-        a.href = cleanYoutubeRedir(a.search);
-      }
-
+      a.href = transformYoutubeUrl(a.href);
       a.cleaned = 1;
       return;
     }
 
     if (host === "getpocket.com") {
-      if (path === "/redirect") {
-        a.href = cleanPocketRedir(a.href);
-      }
+      a.href = transformPocketUrl(a.href);
     }
 
     parserAmazon(a);
@@ -355,14 +347,7 @@
     parserNewegg(a);
     parserIMDB(a);
 
-    if (a.search) {
-      a.search = cleanUtm(a.search);
-    }
-
-    if (a.hash) {
-      a.hash = cleanUtm(a.hash);
-    }
-
+    a.href = transformGlobalUrl(a.href);
     a.cleaned = 1;
   }
 
@@ -401,11 +386,7 @@
       return;
     }
 
-    if (a.pathname.includes("/p/")) {
-      a.href = cleanTargetItemp(a);
-    } else if (a.search) {
-      a.href = cleanTargetParams(a.href);
-    }
+    a.href = transformTargetUrl(a.href);
   }
 
   function parserAmazon(a) {
@@ -429,24 +410,17 @@
       return;
     }
 
-    if (a.search && !a.pathname.includes("/marketplace/")) {
-      a.search = cleanNewegg(a.search);
-    }
+    a.href = transformNeweggUrl(a.href);
   }
 
   function parserIMDB(a) {
-    if (a.host === "www.imdb.com" && a.search) {
-      a.search = cleanImdb(a.search);
+    if (a.host === "www.imdb.com") {
+      a.href = transformImdbUrl(a.href);
     }
   }
 
   function parserGlobal(a) {
-    if (a.search) {
-      a.search = cleanUtm(a.search);
-    }
-    if (a.hash) {
-      a.hash = cleanUtm(a.hash);
-    }
+    a.href = transformGlobalUrl(a.href);
     a.cleaned = 1;
   }
 
@@ -456,21 +430,13 @@
       return;
     }
 
-    if (a.host !== "l.facebook.com") {
-      return;
-    }
-
-    a.href = cleanGenericRedir(a.search);
+    a.href = transformFacebookUrl(a.href);
     a.removeAttribute("onclick");
     a.removeAttribute("onmouseover");
   }
 
   function parserDisqus(a) {
-    if (a.host === "disq.us" && a.pathname === "/url") {
-      a.href = a.href.replace(/\:.*/, "");
-    }
-    a.href = cleanGenericRedir(a.search);
-
+    a.href = transformDisqusUrl(a.href);
     parserAll(a);
   }
 
@@ -670,6 +636,86 @@
     return href;
   }
 
+  function transformYoutubeUrl(href) {
+    var u = new URL(href);
+    if (u.pathname === "/watch") {
+      u.search = cleanYoutube(u.search);
+      return u.href;
+    } else if (u.pathname === "/redirect") {
+      return cleanYoutubeRedir(u.search);
+    }
+    return href;
+  }
+
+  function transformPocketUrl(href) {
+    var u = new URL(href);
+    if (u.host === "getpocket.com" && u.pathname === "/redirect") {
+      return cleanPocketRedir(href);
+    }
+    return href;
+  }
+
+  function transformTargetUrl(href) {
+    var u = new URL(href);
+    if (u.pathname.includes("/p/")) {
+      return cleanTargetItemp(u);
+    } else if (u.search) {
+      return cleanTargetParams(href);
+    }
+    return href;
+  }
+
+  function transformNeweggUrl(href) {
+    var u = new URL(href);
+    if (u.search && !u.pathname.includes("/marketplace/")) {
+      u.search = cleanNewegg(u.search);
+      return u.href;
+    }
+    return href;
+  }
+
+  function transformImdbUrl(href) {
+    var u = new URL(href);
+    if (u.search) {
+      u.search = cleanImdb(u.search);
+      return u.href;
+    }
+    return href;
+  }
+
+  function transformFacebookUrl(href) {
+    var u = new URL(href);
+    if (u.host !== "l.facebook.com") {
+      return href;
+    }
+    return cleanGenericRedir(u.search);
+  }
+
+  // transformDisqusUrl reproduces the CURRENT (broken) parserDisqus behavior exactly.
+  // For disq.us/url: the original sets a.href = a.href.replace(/\:.*/, "") which
+  // strips from the first colon, leaving only "https" — a.search then becomes "",
+  // so cleanGenericRedir("") throws TypeError (null match).
+  // Non-disq.us/url links fall straight to cleanGenericRedir(search) which works.
+  // ponytail: bug — disq.us/url branch always throws; tracked separately for fixing.
+  function transformDisqusUrl(href) {
+    var u = new URL(href);
+    if (u.host === "disq.us" && u.pathname === "/url") {
+      return cleanGenericRedir("");
+    }
+    return cleanGenericRedir(u.search);
+  }
+
+  function transformGlobalUrl(href) {
+    var u = new URL(href);
+    if (u.search) {
+      u.search = cleanUtm(u.search);
+    }
+    if (u.hash) {
+      u.hash = cleanUtm(u.hash);
+    }
+    return u.href;
+  }
+
   // ponytail: Node export + load guard exist only so the pure cleaners are unit-testable; Tampermonkey defines window/document so the guard is a no-op in-browser
   if (typeof module !== "undefined" && module.exports) {
     module.exports = {
@@ -679,7 +725,11 @@
       cleanEbayParams, cleanUtm,
       cleanYoutubeRedir, cleanAmazonRedir, cleanGenericRedir, cleanGenericRedir2, cleanPocketRedir,
       cleanEbayPulsar, cleanEbayItem, cleanAmazonItemdp, cleanAmazonItemgp,
+      cleanTargetItemp,
       transformGoogleUrl, transformAmazonUrl, transformEbayUrl,
+      transformYoutubeUrl, transformPocketUrl, transformTargetUrl,
+      transformNeweggUrl, transformImdbUrl, transformFacebookUrl,
+      transformDisqusUrl, transformGlobalUrl,
       googleParams, ebayParams, amazonParams, neweggParams, imdbParams,
       bingParams, youtubeParams, targetParams,
       facebookParams, linkedinParams, etsyParams, yahooParams,

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -7,6 +7,14 @@ const {
   transformGoogleUrl,
   transformAmazonUrl,
   transformEbayUrl,
+  transformYoutubeUrl,
+  transformPocketUrl,
+  transformTargetUrl,
+  transformNeweggUrl,
+  transformImdbUrl,
+  transformFacebookUrl,
+  transformDisqusUrl,
+  transformGlobalUrl,
 } = require("../URLClean.user.js");
 
 // ---------------------------------------------------------------------------
@@ -198,6 +206,229 @@ describe("transformEbayUrl", () => {
         "https://www.ebay.com"
       ),
       "https://www.ebay.com/sch/i.html?_nkw=keyboard"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformYoutubeUrl
+// /watch → strip tracking params via cleanYoutube
+// /redirect → decode q= param via cleanYoutubeRedir
+// other path → returned unchanged
+// ---------------------------------------------------------------------------
+describe("transformYoutubeUrl", () => {
+  it("strips tracking params from a /watch URL", () => {
+    assert.equal(
+      transformYoutubeUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=share&gl=US"),
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+  });
+
+  it("decodes a /redirect URL to the target", () => {
+    assert.equal(
+      transformYoutubeUrl("https://www.youtube.com/redirect?q=https%3A%2F%2Fexample.com%2Fpage&event=video_description"),
+      "https://example.com/page"
+    );
+  });
+
+  it("passes through a /watch URL with no tracked params", () => {
+    assert.equal(
+      transformYoutubeUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+  });
+
+  it("passes through a non-watch/redirect path unchanged", () => {
+    assert.equal(
+      transformYoutubeUrl("https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"),
+      "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformPocketUrl
+// getpocket.com /redirect → decode via cleanPocketRedir
+// other host/path → returned unchanged
+// ---------------------------------------------------------------------------
+describe("transformPocketUrl", () => {
+  it("decodes a getpocket.com /redirect URL to the target", () => {
+    assert.equal(
+      transformPocketUrl("https://getpocket.com/redirect?url=https%3A%2F%2Fexample.com%2Farticle"),
+      "https://example.com/article"
+    );
+  });
+
+  it("passes through a non-redirect getpocket.com URL unchanged", () => {
+    assert.equal(
+      transformPocketUrl("https://getpocket.com/explore/trending"),
+      "https://getpocket.com/explore/trending"
+    );
+  });
+
+  it("passes through a non-getpocket.com URL unchanged", () => {
+    assert.equal(
+      transformPocketUrl("https://example.com/redirect?url=https%3A%2F%2Fother.com%2F"),
+      "https://example.com/redirect?url=https%3A%2F%2Fother.com%2F"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformTargetUrl
+// pathname includes /p/ → canonicalise via cleanTargetItemp (strips slug/query)
+// else search present → strip tracking params via cleanTargetParams
+// clean URL → returned unchanged
+// ---------------------------------------------------------------------------
+describe("transformTargetUrl", () => {
+  it("canonicalises a /p/ product URL by stripping slug and query", () => {
+    assert.equal(
+      transformTargetUrl("https://www.target.com/p/some-product-name/-/A-12345678?lnk=sametab&preselect=12345678"),
+      "https://www.target.com/p/A-12345678"
+    );
+  });
+
+  it("strips tracked query params from a non-product URL (trailing ? is preserved by cleanTargetParams)", () => {
+    assert.equal(
+      transformTargetUrl("https://www.target.com/c/toys/-/N-5xtg3?lnk=snav_ta_toys&tref=homepage"),
+      "https://www.target.com/c/toys/-/N-5xtg3?"
+    );
+  });
+
+  it("passes through a clean URL with no tracked params unchanged", () => {
+    assert.equal(
+      transformTargetUrl("https://www.target.com/c/toys/-/N-5xtg3"),
+      "https://www.target.com/c/toys/-/N-5xtg3"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformNeweggUrl
+// search and no /marketplace/ → strip tracking params via cleanNewegg
+// /marketplace/ → passthrough even with search
+// no search → passthrough
+// ---------------------------------------------------------------------------
+describe("transformNeweggUrl", () => {
+  it("strips tracking params from a product URL", () => {
+    assert.equal(
+      transformNeweggUrl("https://www.newegg.com/p/N82E16834234989?Item=N82E16834234989&cm_sp=Top+Sellers-_-2-_-N82E16834234989&icid=LSSA_8B734_0019"),
+      "https://www.newegg.com/p/N82E16834234989?Item=N82E16834234989"
+    );
+  });
+
+  it("passes through a /marketplace/ URL unchanged even with tracked params", () => {
+    assert.equal(
+      transformNeweggUrl("https://www.newegg.com/marketplace/seller/profile/abc?cm_sp=track&icid=xyz"),
+      "https://www.newegg.com/marketplace/seller/profile/abc?cm_sp=track&icid=xyz"
+    );
+  });
+
+  it("passes through a URL with no search params unchanged", () => {
+    assert.equal(
+      transformNeweggUrl("https://www.newegg.com/p/N82E16834234989"),
+      "https://www.newegg.com/p/N82E16834234989"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformImdbUrl
+// search present → strip tracking params via cleanImdb
+// no search → passthrough
+// ---------------------------------------------------------------------------
+describe("transformImdbUrl", () => {
+  it("strips tracking params from an IMDB URL", () => {
+    assert.equal(
+      transformImdbUrl("https://www.imdb.com/title/tt0111161/?pf_rd_m=A2FGELUUNOQJNL&ref_=nv_sr_srsg_0"),
+      "https://www.imdb.com/title/tt0111161/"
+    );
+  });
+
+  it("passes through a clean IMDB URL unchanged", () => {
+    assert.equal(
+      transformImdbUrl("https://www.imdb.com/title/tt0111161/"),
+      "https://www.imdb.com/title/tt0111161/"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformFacebookUrl
+// l.facebook.com host → decode via cleanGenericRedir
+// other host → passthrough
+// ---------------------------------------------------------------------------
+describe("transformFacebookUrl", () => {
+  it("decodes an l.facebook.com redirect to the target URL", () => {
+    assert.equal(
+      transformFacebookUrl("https://l.facebook.com/l.php?u=https%3A%2F%2Fexample.com%2Fpage&h=AT0abc"),
+      "https://example.com/page"
+    );
+  });
+
+  it("passes through a non-l.facebook.com URL unchanged", () => {
+    assert.equal(
+      transformFacebookUrl("https://www.facebook.com/someprofile?ref=bookmark"),
+      "https://www.facebook.com/someprofile?ref=bookmark"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformDisqusUrl — characterization of CURRENT (broken) behavior
+// disq.us /url: original code strips href from first colon → a.search becomes ""
+//   → cleanGenericRedir("") throws TypeError (null.pop)
+// other disqus links: cleanGenericRedir(search) runs on original search
+// ---------------------------------------------------------------------------
+describe("transformDisqusUrl", () => {
+  it("throws TypeError for disq.us/url links (characterizes current broken behavior)", () => {
+    assert.throws(
+      () => transformDisqusUrl("https://disq.us/url?url=https%3A%2F%2Fexample.com%2Fpage&cuid=123"),
+      TypeError
+    );
+  });
+
+  it("decodes a non-/url disqus link via cleanGenericRedir", () => {
+    assert.equal(
+      transformDisqusUrl("https://disq.us/somepath?url=https%3A%2F%2Fexample.com%2Fpage"),
+      "https://example.com/page"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformGlobalUrl
+// utm_ params in search → stripped
+// utm_ params in hash → stripped
+// non-utm params → preserved
+// clean URL → passthrough
+// ---------------------------------------------------------------------------
+describe("transformGlobalUrl", () => {
+  it("strips utm_ params from search while preserving non-utm params", () => {
+    assert.equal(
+      transformGlobalUrl("https://example.com/page?ref=newsletter&utm_source=email&utm_medium=cpc&q=test"),
+      "https://example.com/page?ref=newsletter&q=test"
+    );
+  });
+
+  it("strips utm_ params from a hash", () => {
+    assert.equal(
+      transformGlobalUrl("https://example.com/page#section?utm_source=twitter&utm_campaign=launch"),
+      "https://example.com/page#section"
+    );
+  });
+
+  it("passes through a URL with no utm_ params unchanged", () => {
+    assert.equal(
+      transformGlobalUrl("https://example.com/page?q=hello&page=2"),
+      "https://example.com/page?q=hello&page=2"
+    );
+  });
+
+  it("passes through a URL with no search or hash unchanged", () => {
+    assert.equal(
+      transformGlobalUrl("https://example.com/page"),
+      "https://example.com/page"
     );
   });
 });


### PR DESCRIPTION
Closes #53. Continuation of #52, applying the ADR-0001 pure-transform seam to the remaining parsers.

## What
Extracts the URL-transformation core out of the remaining parsers into pure exported `transform*Url(href)` helpers (all branching/regex internal, no DOM access); the DOM wrappers keep only host-guard + attribute I/O.

- New helpers: `transformYoutubeUrl`, `transformPocketUrl`, `transformTargetUrl`, `transformNeweggUrl`, `transformImdbUrl`, `transformFacebookUrl`, `transformDisqusUrl`, `transformGlobalUrl`.
- Wrappers thinned: `parserAll` (youtube/getpocket branches + the trailing UTM block), `parserTarget`, `parserNewegg`, `parserIMDB`, `parserFacebook` (onclick DOM gate retained), `parserDisqus` (still dispatches to `parserAll`), `parserGlobal`.
- Removed the now-dead `path` local in `parserAll`.

## Disqus characterization (pre-existing bug, preserved + filed)
`parserDisqus`'s `disq.us/url` branch does `a.href = a.href.replace(/\:.*/, "")`, which strips from the protocol colon (→ `"https"`), then calls `cleanGenericRedir("")` → throws `TypeError`. This refactor reproduces that behavior exactly (the characterization test documents it via `assert.throws`) rather than silently fixing it. Filed as #69.

## Tests
`test/parsers.test.js` — +23 characterization tests (strip + passthrough per transform). Full suite: `node --test` → **133 pass, 0 fail**.

## Live --chrome QA (acceptance criterion)
Ran the extracted transforms against real anchor hrefs on live pages:
- **YouTube** (`/results`): 12 `/watch` links, 0 errors, tracking stripped, `v` preserved 12/12. (`/redirect` not present in search markup — covered by unit test.)
- **Target** (`/s`): 155 links, 0 errors, 130/130 `/p/` PDPs canonicalized, tracking stripped.
- **Newegg** (`/p/pl`): 1857 links (94 tracked), 0 errors, tracking stripped.
- **IMDB** (`/find`): 94 links (all `ref_`-tracked), 0 errors, stripped.
- **Global UTM**: 120 real links, 0 throws; strip / passthrough / all-utm-clears-query confirmed.

Could not be exercised live (rely on unit coverage):
- **Facebook** — `l.facebook.com` link-shim links only appear in a logged-in feed (no credential entry).
- **Disqus** — `/url` path throws by design (#69); nothing valid to exercise.
- **Pocket** — `getpocket.com/redirect` endpoint retired (Pocket shut down 2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
