### PR TITLE
chore: remove dead Pocket handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>General URL Cleaner Revived</h1>
-Cleans various URL's and/or page links on Google, Youtube, Newegg, Amazon, Ebay, Facebook, Twitter, IMDB, StaticICE, Pocket, Target<br><br>
+Cleans various URL's and/or page links on Google, Youtube, Newegg, Amazon, Ebay, Facebook, Twitter, IMDB, StaticICE, Target<br><br>
 It will clean these URLs regardless of what top level domain (.com, .ca, .fr, etc) or subdomain (unless excluded, various Google sites break easily like Docs, Hangouts, Takeout, etc)<br>
 <br>Feel free to report issues or make pull requests for fixes, enhancements, etc: https://github.com/dividedby/General-URL-Cleaner-Revived<br><br>
 https://greasyfork.org/en/scripts/432387-general-url-cleaner-revived
@@ -42,9 +42,6 @@ Cleaned url always looks like this: http://www.newegg.com/Product/Product.aspx?I
 <h3>Ebay</h3>
 Cleaned url always looks like this: http://www.ebay.com/itm/[item-id]<br>
 Works with international sites (not just .com)
-
-<h3>Pocket</h3>
-Removes redirection of Pocket links
 
 <h3>Target</h3>
 Target product URLs must be reloaded when coming from search results as they load in via code and not a page refresh<br>

--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -3,7 +3,7 @@
 // @namespace   https://greasyfork.org/en/users/594496-divided-by
 // @author      dividedby
 // @description Cleans URLs from various popular sites and removes tracking parameters
-// @version     4.2.6
+// @version     4.2.7
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
 // @contributionURL     https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=dividedbygit@gmail.com&item_name=Greasy+Fork+Donation
 // @contributionAmount  $1
@@ -221,11 +221,6 @@
       return;
     }
 
-    if (currHost === "app.getpocket.com") {
-      cleanLinks(parserAll);
-      return;
-    }
-
     // ponytail: no dedicated handler for this host — strip generic trackers
     // everywhere unless the user opted out. Ceiling: one MutationObserver per
     // page; opt out via GLOBAL_STRIP.
@@ -336,10 +331,6 @@
       a.href = transformYoutubeUrl(a.href);
       a.cleaned = 1;
       return;
-    }
-
-    if (host === "getpocket.com") {
-      a.href = transformPocketUrl(a.href);
     }
 
     parserAmazon(a);
@@ -578,12 +569,6 @@
     return url;
   }
 
-  function cleanPocketRedir(url) {
-    return decodeURIComponent(
-      url.replace("https://getpocket.com/redirect?url=", "")
-    );
-  }
-
   function transformGoogleUrl(href) {
     var u = new URL(href);
     if (u.pathname === "/imgres" || u.pathname === "/url") {
@@ -643,14 +628,6 @@
       return u.href;
     } else if (u.pathname === "/redirect") {
       return cleanYoutubeRedir(u.search);
-    }
-    return href;
-  }
-
-  function transformPocketUrl(href) {
-    var u = new URL(href);
-    if (u.host === "getpocket.com" && u.pathname === "/redirect") {
-      return cleanPocketRedir(href);
     }
     return href;
   }
@@ -723,11 +700,11 @@
       cleanYoutube, cleanImdb, cleanNewegg,
       cleanTargetParams, cleanFacebookParams, cleanAmazonParams, cleanAudible,
       cleanEbayParams, cleanUtm,
-      cleanYoutubeRedir, cleanAmazonRedir, cleanGenericRedir, cleanGenericRedir2, cleanPocketRedir,
+      cleanYoutubeRedir, cleanAmazonRedir, cleanGenericRedir, cleanGenericRedir2,
       cleanEbayPulsar, cleanEbayItem, cleanAmazonItemdp, cleanAmazonItemgp,
       cleanTargetItemp,
       transformGoogleUrl, transformAmazonUrl, transformEbayUrl,
-      transformYoutubeUrl, transformPocketUrl, transformTargetUrl,
+      transformYoutubeUrl, transformTargetUrl,
       transformNeweggUrl, transformImdbUrl, transformFacebookUrl,
       transformDisqusUrl, transformGlobalUrl,
       googleParams, ebayParams, amazonParams, neweggParams, imdbParams,

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -22,7 +22,6 @@ const {
   cleanAmazonRedir,
   cleanGenericRedir,
   cleanGenericRedir2,
-  cleanPocketRedir,
 } = require("../URLClean.user.js");
 
 // ---------------------------------------------------------------------------
@@ -531,54 +530,6 @@ describe("cleanGenericRedir2", () => {
 
   it("throws when no *url= param is present (no passthrough)", () => {
     assert.throws(() => cleanGenericRedir2("?q=hello"), TypeError);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// cleanPocketRedir
-// Input: the FULL href of the anchor (not just the search string).
-// Strips the literal prefix "https://getpocket.com/redirect?url=" via
-// String.replace(), then calls decodeURIComponent on the remainder.
-//
-// SURPRISING BEHAVIORS encoded here:
-// 1. Already-clean URL (no pocket prefix): prefix replace is a no-op, then
-//    decodeURIComponent is called on the original URL — returns it unchanged
-//    for plain ASCII URLs (no actual passthrough guard).
-// 2. Trailing params after url=: the literal-replace leaves them in the
-//    decoded string as "target-url&param=val" (not split on &).
-// 3. Double-encoded target: only one layer of decoding applied.
-// ---------------------------------------------------------------------------
-describe("cleanPocketRedir", () => {
-  it("decodes a real Pocket redirect href to the target URL", () => {
-    assert.equal(
-      cleanPocketRedir("https://getpocket.com/redirect?url=https%3A%2F%2Fexample.com%2Farticle"),
-      "https://example.com/article"
-    );
-  });
-
-  it("passes through an already-clean URL (prefix absent, decodeURIComponent is no-op on ASCII)", () => {
-    // CURRENT BEHAVIOR: prefix not found → replace no-op → decodeURIComponent('https://example.com/article')
-    // = 'https://example.com/article'
-    assert.equal(
-      cleanPocketRedir("https://example.com/article"),
-      "https://example.com/article"
-    );
-  });
-
-  it("trailing params after url= leak into the decoded target (known behavior)", () => {
-    // CURRENT BEHAVIOR: literal replace strips only the prefix, leaving the rest
-    // of the query string attached to the decoded target via a literal '&'.
-    assert.equal(
-      cleanPocketRedir("https://getpocket.com/redirect?url=https%3A%2F%2Fexample.com%2Farticle&form_check=abc"),
-      "https://example.com/article&form_check=abc"
-    );
-  });
-
-  it("only decodes one layer — double-encoded target remains partially encoded", () => {
-    assert.equal(
-      cleanPocketRedir("https://getpocket.com/redirect?url=https%253A%252F%252Fexample.com%252Farticle"),
-      "https%3A%2F%2Fexample.com%2Farticle"
-    );
   });
 });
 

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -8,7 +8,6 @@ const {
   transformAmazonUrl,
   transformEbayUrl,
   transformYoutubeUrl,
-  transformPocketUrl,
   transformTargetUrl,
   transformNeweggUrl,
   transformImdbUrl,
@@ -242,34 +241,6 @@ describe("transformYoutubeUrl", () => {
     assert.equal(
       transformYoutubeUrl("https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"),
       "https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw"
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// transformPocketUrl
-// getpocket.com /redirect → decode via cleanPocketRedir
-// other host/path → returned unchanged
-// ---------------------------------------------------------------------------
-describe("transformPocketUrl", () => {
-  it("decodes a getpocket.com /redirect URL to the target", () => {
-    assert.equal(
-      transformPocketUrl("https://getpocket.com/redirect?url=https%3A%2F%2Fexample.com%2Farticle"),
-      "https://example.com/article"
-    );
-  });
-
-  it("passes through a non-redirect getpocket.com URL unchanged", () => {
-    assert.equal(
-      transformPocketUrl("https://getpocket.com/explore/trending"),
-      "https://getpocket.com/explore/trending"
-    );
-  });
-
-  it("passes through a non-getpocket.com URL unchanged", () => {
-    assert.equal(
-      transformPocketUrl("https://example.com/redirect?url=https%3A%2F%2Fother.com%2F"),
-      "https://example.com/redirect?url=https%3A%2F%2Fother.com%2F"
     );
   });
 });


### PR DESCRIPTION
## What
Removes all Pocket (getpocket.com) handling — it's dead code. Mozilla shut Pocket down in 2025 and the redirect endpoints are gone.

Removed:
- `app.getpocket.com` dispatch branch and the `getpocket.com` branch in `parserAll`
- `cleanPocketRedir` and `transformPocketUrl` (+ their `module.exports` entries)
- Pocket unit tests (4 in `cleaners.test.js`, 3 in `parsers.test.js`)
- README mentions
- `@version` 4.2.6 → 4.2.7

## Tests
`node --test` → **126 pass, 0 fail** (was 133; −7 Pocket tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
