### PR TITLE
fix: match Amazon ASIN anywhere in /dp/ path (#66)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -519,8 +519,9 @@
   }
 
   function cleanAmazonItemdp(a) {
-    let item = a.pathname.match(/\/dp(\/[A-Z0-9]{10})/)[1];
-    return a.origin + "/dp" + item + a.hash;
+    let m = a.pathname.match(/\/([A-Z0-9]{10})(?=[/?]|$)/);
+    if (!m) return a.href;
+    return a.origin + "/dp/" + m[1] + a.hash;
   }
 
   function cleanEbayItem(a) {

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -89,6 +89,25 @@ describe("transformAmazonUrl", () => {
     );
   });
 
+  it("canonicalises a /dp/product/<ASIN> URL (ASIN not immediately after /dp/)", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/dp/product/B07XYZ1234/ref=sr_1_1?keywords=widget"
+      ),
+      "https://www.amazon.com/dp/B07XYZ1234"
+    );
+  });
+
+  it("returns href unchanged when /dp/ path contains no ASIN (no TypeError)", () => {
+    assert.doesNotThrow(() =>
+      transformAmazonUrl("https://www.amazon.com/dp/product/")
+    );
+    assert.equal(
+      transformAmazonUrl("https://www.amazon.com/dp/product/"),
+      "https://www.amazon.com/dp/product/"
+    );
+  });
+
   it("canonicalises a /gp/product URL", () => {
     assert.equal(
       transformAmazonUrl(


### PR DESCRIPTION
## Summary
- `cleanAmazonItemdp` extracted the ASIN with `/\/dp(\/[A-Z0-9]{10})/`, which assumes the ASIN sits immediately after `/dp/`. A `/dp/product/<ASIN>` path returned `null`, and `[1]` threw a `TypeError` that aborted the MutationObserver link-cleaning batch.
- Now matches the 10-char ASIN anywhere in the path (`/\/([A-Z0-9]{10})(?=[/?]|$)/`) and passes the href through unchanged when no ASIN is present. Canonical output (`/dp/<ASIN>` + hash) is identical for existing id-bearing paths.

## Test plan
- [x] New char test: `/dp/product/<ASIN>` canonicalises to `/dp/<ASIN>`.
- [x] New char test: no-ASIN `/dp/` path passes through without throwing.
- [x] Existing id-bearing Amazon assertions unchanged.
- [x] `node --test` green: 129 pass, 0 fail.

Closes #66

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
