### PR TITLE
fix: pass through id-less eBay /itm/ links instead of /itmnull (#67)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -526,6 +526,7 @@
 
   function cleanEbayItem(a) {
     let item = a.pathname.match(/\/[0-9]{12}/);
+    if (!item) return a.href;
     let origList = a.search.replace(/&/g, "?").match(/\?orig_cvip=[^?]+/) || "";
     return a.origin + "/itm" + item + origList + a.hash;
   }

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -226,6 +226,17 @@ describe("transformEbayUrl", () => {
       "https://www.ebay.com/sch/i.html?_nkw=keyboard"
     );
   });
+
+  it("passes through an /itm/ URL unchanged when no 12-digit id is present", () => {
+    // bug fix: previously emitted /itmnull; now leaves href unchanged
+    assert.equal(
+      transformEbayUrl(
+        "https://www.ebay.com/itm/wireless-headphones?_trksid=p4375.c101",
+        "https://www.ebay.com"
+      ),
+      "https://www.ebay.com/itm/wireless-headphones?_trksid=p4375.c101"
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `cleanEbayItem` built `a.origin + "/itm" + item + ...` where `item = a.pathname.match(/\/[0-9]{12}/)`. When an `/itm/` link had no 12-digit id, `item` was `null` and the result became a malformed `https://www.ebay.com/itmnull` written back to the link.
- Added an early passthrough (`if (!item) return a.href;`) so id-less `/itm/` links are left unchanged. Output for id-bearing `/itm/<id>` links is byte-identical.

## Test plan
- [x] New char test: id-less `/itm/` URL passes through unchanged (no `/itmnull`).
- [x] Existing id-bearing eBay assertions unchanged.
- [x] `node --test` green: 130 pass, 0 fail.

Closes #67

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
