### PR TITLE
feat: add param-only stripping for Spotify, Reddit, Twitch, Threads (#74)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -22,6 +22,15 @@
 // @include     /^https:\/\/[a-z0-9.]*\.?audible(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?google(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
 // @include     /^https:\/\/[a-z0-9.]*\.?ebay(desc)?(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/.*$/
+// @include     https://open.spotify.com/*
+// @include     https://www.reddit.com/*
+// @include     https://reddit.com/*
+// @include     https://www.twitch.tv/*
+// @include     https://twitch.tv/*
+// @include     https://www.threads.net/*
+// @include     https://threads.net/*
+// @include     https://www.threads.com/*
+// @include     https://threads.com/*
 // @include     *
 // @exclude     /^https:\/\/[a-z0-9.]*\.?amazon(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/(?:gp\/(?:cart|buy|css|legacy|your-account).*|sspa.*)$/
 // @exclude     https://apis.google.com/*
@@ -76,6 +85,10 @@
   const etsyParams =
     /&(click_key|click_sum|ref|pro|frs|ga_order|ga_search_type|ga_view_type|ga_search_query|sts|organic_search_click|plkey)(=[^&#]*)?(?=$|&)/g;
   const yahooParams = /&(guccounter|guce_referrer|guce_referrer_sig)(=[^&#]*)?(?=$|&)/g;
+  const spotifyParams = /&(si)(=[^&#]*)?(?=$|&)/g;
+  const redditParams = /&(correlation_id|ref_campaign|ref_source|share_id)(=[^&#]*)?(?=$|&)/g;
+  const twitchParams = /&(tt_medium|tt_content)(=[^&#]*)?(?=$|&)/g;
+  const threadsParams = /&(xmt)(=[^&#]*)?(?=$|&)/g;
   // Universal click-id / email-tracking params safe to strip on every site.
   // Sourced from AdGuard URL Tracking filter, ClearURLs, and Brave's query-string filter.
   // Excludes: _gl (GA4 cross-domain stitching), mkt_tok (Marketo unsubscribe path),
@@ -224,6 +237,43 @@
 
     if (currHost == "disqus.com") {
       cleanLinks(parserDisqus);
+      return;
+    }
+
+    if (currHost === "open.spotify.com") {
+      if (currSearch) {
+        setCurrUrl(cleanSpotify(currSearch));
+      }
+
+      cleanLinks(parserAll);
+      return;
+    }
+
+    if (currHost === "www.reddit.com" || currHost === "reddit.com") {
+      if (currSearch) {
+        setCurrUrl(cleanReddit(currSearch));
+      }
+
+      cleanLinks(parserAll);
+      return;
+    }
+
+    if (currHost === "www.twitch.tv" || currHost === "twitch.tv") {
+      if (currSearch) {
+        setCurrUrl(cleanTwitch(currSearch));
+      }
+
+      cleanLinks(parserAll);
+      return;
+    }
+
+    if (currHost === "www.threads.net" || currHost === "threads.net" ||
+        currHost === "www.threads.com" || currHost === "threads.com") {
+      if (currSearch) {
+        setCurrUrl(cleanThreads(currSearch));
+      }
+
+      cleanLinks(parserAll);
       return;
     }
 
@@ -489,6 +539,22 @@
     return cleanParams(url, facebookParams);
   }
 
+  function cleanSpotify(url) {
+    return cleanParams(url, spotifyParams);
+  }
+
+  function cleanReddit(url) {
+    return cleanParams(url, redditParams);
+  }
+
+  function cleanTwitch(url) {
+    return cleanParams(url, twitchParams);
+  }
+
+  function cleanThreads(url) {
+    return cleanParams(url, threadsParams);
+  }
+
   function cleanAmazonParams(url) {
     return cleanParams(url, amazonParams, true);
   }
@@ -725,6 +791,7 @@
       cleanYoutube, cleanImdb, cleanNewegg,
       cleanTargetParams, cleanFacebookParams, cleanAmazonParams, cleanAudible,
       cleanEbayParams, cleanUtm, cleanGlobalParams,
+      cleanSpotify, cleanReddit, cleanTwitch, cleanThreads,
       cleanYoutubeRedir, cleanAmazonRedir, cleanGenericRedir, cleanGenericRedir2,
       cleanEbayPulsar, cleanEbayItem, cleanAmazonItemdp, cleanAmazonItemgp,
       cleanTargetItemp,
@@ -735,6 +802,7 @@
       googleParams, ebayParams, amazonParams, neweggParams, imdbParams,
       bingParams, youtubeParams, targetParams,
       facebookParams, linkedinParams, etsyParams, yahooParams, globalParams,
+      spotifyParams, redditParams, twitchParams, threadsParams,
     };
   }
 })();

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -23,6 +23,10 @@ const {
   cleanAmazonRedir,
   cleanGenericRedir,
   cleanGenericRedir2,
+  cleanSpotify,
+  cleanReddit,
+  cleanTwitch,
+  cleanThreads,
 } = require("../URLClean.user.js");
 
 // ---------------------------------------------------------------------------
@@ -1267,6 +1271,197 @@ describe("cleanGlobalParams", () => {
     assert.equal(
       cleanGlobalParams("https://example.com/?fbclid=x&gclid=y"),
       "https://example.com/"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanSpotify
+// Strips: si (Spotify share/session identity token)
+// Keeps:  functional params (no known functional params share the name "si")
+// ---------------------------------------------------------------------------
+describe("cleanSpotify", () => {
+  it("strips si while keeping no other params", () => {
+    assert.equal(
+      cleanSpotify("?si=abc123"),
+      "?"
+    );
+  });
+
+  it("strips si while keeping a hypothetical functional param", () => {
+    // Verify separator fixup: functional param before si survives intact
+    assert.equal(
+      cleanSpotify("?go=1&si=abc123"),
+      "?go=1"
+    );
+  });
+
+  it("strips si at start, keeps trailing functional param", () => {
+    assert.equal(
+      cleanSpotify("?si=abc123&go=1"),
+      "?go=1"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanSpotify("?go=1"),
+      "?go=1"
+    );
+  });
+
+  it("passes through a URL with no query string unchanged", () => {
+    assert.equal(
+      cleanSpotify("https://open.spotify.com/track/123"),
+      "https://open.spotify.com/track/123"
+    );
+  });
+
+  it("is idempotent on an already-clean search string", () => {
+    assert.equal(cleanSpotify("?go=1"), "?go=1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanReddit
+// Strips: correlation_id, ref_campaign, ref_source, share_id
+// Keeps:  q, sort, t, after (functional pagination/search/sort params)
+// Note: plain `ref` is NOT stripped — it is functional on Reddit (subreddit
+// context); only ref_campaign and ref_source (campaign-tracking variants) are.
+// ---------------------------------------------------------------------------
+describe("cleanReddit", () => {
+  it("strips share_id while keeping q and sort", () => {
+    assert.equal(
+      cleanReddit("?q=cats&sort=new&share_id=XYZ"),
+      "?q=cats&sort=new"
+    );
+  });
+
+  it("strips correlation_id while keeping sort and t", () => {
+    assert.equal(
+      cleanReddit("?sort=top&t=week&correlation_id=abc"),
+      "?sort=top&t=week"
+    );
+  });
+
+  it("strips ref_campaign and ref_source, keeps q", () => {
+    assert.equal(
+      cleanReddit("?q=dogs&ref_campaign=email&ref_source=newsletter"),
+      "?q=dogs"
+    );
+  });
+
+  it("preserves functional sort and t params", () => {
+    assert.equal(
+      cleanReddit("?sort=hot&t=all"),
+      "?sort=hot&t=all"
+    );
+  });
+
+  it("preserves plain ref param (functional, not stripped)", () => {
+    assert.equal(
+      cleanReddit("?ref=sidebar&q=news"),
+      "?ref=sidebar&q=news"
+    );
+  });
+
+  it("strips all four tracking params, leaves bare ?", () => {
+    assert.equal(
+      cleanReddit("?correlation_id=a&ref_campaign=b&ref_source=c&share_id=d"),
+      "?"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanReddit("?q=programming&sort=new&t=week"),
+      "?q=programming&sort=new&t=week"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanTwitch
+// Strips: tt_medium, tt_content (Twitch campaign tracking params)
+// Keeps:  functional params (channel, quality, volume, etc.)
+// ---------------------------------------------------------------------------
+describe("cleanTwitch", () => {
+  it("strips tt_medium while keeping a functional param", () => {
+    assert.equal(
+      cleanTwitch("?channel=streamer&tt_medium=social"),
+      "?channel=streamer"
+    );
+  });
+
+  it("strips tt_content while keeping a functional param", () => {
+    assert.equal(
+      cleanTwitch("?channel=streamer&tt_content=banner"),
+      "?channel=streamer"
+    );
+  });
+
+  it("strips both tt_medium and tt_content, keeps functional params", () => {
+    assert.equal(
+      cleanTwitch("?quality=auto&tt_medium=email&tt_content=hero"),
+      "?quality=auto"
+    );
+  });
+
+  it("strips both when they are the only params, leaves bare ?", () => {
+    assert.equal(
+      cleanTwitch("?tt_medium=social&tt_content=banner"),
+      "?"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanTwitch("?channel=streamer&quality=auto"),
+      "?channel=streamer&quality=auto"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanThreads
+// Strips: xmt (Threads share token)
+// Keeps:  functional params
+// Note: igshid/igsh are handled globally by cleanGlobalParams — not added here
+// to avoid redundancy, but this cleaner handles the Threads-specific xmt param.
+// ---------------------------------------------------------------------------
+describe("cleanThreads", () => {
+  it("strips xmt while keeping a functional param", () => {
+    assert.equal(
+      cleanThreads("?igshid=abc&xmt=xyz"),
+      "?igshid=abc"
+    );
+  });
+
+  it("strips xmt when it is the only param, leaves bare ?", () => {
+    assert.equal(
+      cleanThreads("?xmt=xyz"),
+      "?"
+    );
+  });
+
+  it("strips xmt at start, keeps trailing functional param", () => {
+    assert.equal(
+      cleanThreads("?xmt=xyz&ref=home"),
+      "?ref=home"
+    );
+  });
+
+  it("passes through a URL with no tracked params unchanged", () => {
+    assert.equal(
+      cleanThreads("?igshid=abc"),
+      "?igshid=abc"
+    );
+  });
+
+  it("passes through a URL with no query string unchanged", () => {
+    assert.equal(
+      cleanThreads("https://www.threads.net/@user/post/abc"),
+      "https://www.threads.net/@user/post/abc"
     );
   });
 });


### PR DESCRIPTION
## Summary
- Adds param-only tracking-param stripping for four new sites via the existing add-a-site pattern (@match → param regex → `cleanParams`-based cleaner → dispatch → exports):
  - **Spotify**: `si`
  - **Reddit**: `correlation_id`, `ref_campaign`, `ref_source`, `share_id`
  - **Twitch**: `tt_medium`, `tt_content`
  - **Threads**: `xmt` (`igshid`/`igsh` already covered globally by #73)
- Param names copied from prior-art (ClearURLs/AdGuard) — no external list, no runtime dependency, no `package.json`.
- Functional params deliberately preserved (Reddit `ref`/`sort`/`t`, Spotify playback `context`).

## Test plan
- [x] Per-site strip-the-tracker + preserve-the-functional-param cases (23 new).
- [x] Cleaners use the consolidated `cleanParams` idiom (post-#57).
- [x] #30 ampersand regression still green.
- [x] `node --test` green: 214 pass, 0 fail.

## Manual QA note
Param-only sites need no DOM/parser logic; behavior is fully covered by the offline suite.

Closes #74

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
