### PR TITLE
fix: gate parserFacebook on host+path, not stale onclick (#71)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -472,8 +472,7 @@
   }
 
   function parserFacebook(a) {
-    let onclick = a.getAttribute("onclick");
-    if (!onclick || !onclick.startsWith("LinkshimAsyncLink")) {
+    if (a.host !== "l.facebook.com" || a.pathname !== "/l.php") {
       return;
     }
 


### PR DESCRIPTION
## Summary
- `parserFacebook` gated on an inline `onclick="LinkshimAsyncLink..."` attribute that modern Facebook no longer emits, so it early-returned on every `l.facebook.com/l.php?u=<encoded>` shim and link cleaning never ran.
- Now gates on `a.host === "l.facebook.com" && a.pathname === "/l.php"`. The pure `transformFacebookUrl` core (already correct and unit-tested) and the best-effort `removeAttribute` calls are unchanged. DOM-wrapper-only change.

## Test plan
- [x] `node --test` green: 214 pass, 0 fail (unchanged — pure core untouched).
- [x] Live `--chrome` confirmation on a logged-in feed: 6/6 `l.facebook.com` anchors had no `onclick` (old gate skipped all); all pass the new gate and decode to real destinations (`www.meta.ai`, `ad.doubleclick.net`, `www.getjobber.com`), 0 errors.

Closes #71

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
