### PR TITLE
perf: skip injection in subframes except Disqus embed (#55)

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -118,6 +118,14 @@
    */
 
   if (_domAvailable) {
+    // ponytail: cheap @noframes equivalent — skip injection in subframes so
+    // embed-heavy pages don't get a MutationObserver per ad/tracking iframe.
+    // Exception: the Disqus comment widget only ever loads inside an iframe
+    // (@include disqus.com/embed/comments/*), so it must keep running there.
+    if (window.self !== window.top && currHost !== "disqus.com") {
+      return;
+    }
+
     if (bing.test(currHost)) {
       setCurrUrl(cleanBing(currSearch));
       cleanLinks(parserAll);


### PR DESCRIPTION
## Summary
- Skip injection in subframes at the top of dispatch, so embed-heavy pages no longer get a MutationObserver per ad/tracking iframe (the overhead `@noframes` targets in #55).
- Keep the Disqus comment-link flow working via a `disqus.com` host exception — its widget (`@include disqus.com/embed/comments/*`) only ever loads inside an iframe, so bare `@noframes` would have silently regressed it.

## Decision record (#55)
- **Subframe dependency found:** Disqus (`URLClean.user.js:16`, `:255-258`) requires subframe execution.
- **Decision:** do not add `@noframes` (all-or-nothing, would break Disqus); use a 3-line JS frame-guard with a Disqus exception instead.

## Test plan
- [x] `node --test` — 249 pass, 0 fail
- [ ] Live `--chrome`: top-frame injection confirmed on a dedicated site
- [ ] Live `--chrome`: Disqus still cleans links inside its embed iframe
- [ ] Live `--chrome`: no observer installed in non-Disqus subframes on an embed-heavy page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
