### PR TITLE
chore: ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.claude/gearbox-log.jsonl
+.claude/
 .DS_Store


### PR DESCRIPTION
## Summary
- Replace the narrow `.claude/gearbox-log.jsonl` ignore with the whole `.claude/` directory so local agent config stays untracked.

## Test plan
- [ ] `git status` shows `.claude/` as ignored (not untracked)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
