### PR TITLE
chore: bump version to 5.0.0

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -3,7 +3,7 @@
 // @namespace   https://greasyfork.org/en/users/594496-divided-by
 // @author      dividedby
 // @description Cleans URLs from various popular sites and removes tracking parameters
-// @version     4.2.7
+// @version     5.0.0
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
 // @contributionURL     https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=dividedbygit@gmail.com&item_name=Greasy+Fork+Donation
 // @contributionAmount  $1


### PR DESCRIPTION
## Summary
- Bump `@version` 4.2.7 → 5.0.0, reflecting the site additions and cleaning-engine rework accumulated since 4.2.7.

## Test plan
- [ ] `@version` reads 5.0.0 in the userscript header
- [ ] `node --test` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
