### PR TITLE
docs: add 5.0 What's new section to README and GreasyFork listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ in your browser bar and the links on the page.
 - **Issues / PRs:** [GitHub](https://github.com/dividedby/General-URL-Cleaner-Revived)
 - **Forked from** [beck's General URL Cleaner](https://greasyfork.org/en/scripts/395298-general-url-cleaner).
 
+## What's new in 5.0
+
+A major release built up across many fixes, new site coverage, and an
+engine rewrite.
+
+- **New site support:** Bing, Audible, LinkedIn, Etsy, Yahoo, Spotify,
+  Reddit, Twitch, Threads, AliExpress, Walmart, Best Buy, and TikTok.
+- **Global tracking-param stripping:** `utm_*` and common click-ID
+  parameters are now removed on *every* site, not just ones with a dedicated
+  handler (opt-out via the `GLOBAL_STRIP` flag).
+- **Cleaning fixes:** Google (`sclient`/`ping`/`authuser`), eBay, Amazon
+  (`/dp/` and `/gp/product/`), Disqus, Facebook, and a long-standing
+  trailing-ampersand bug.
+- **SPA-aware:** link cleaning now follows in-page navigation via
+  `hashchange` and a `MutationObserver`, and skips injection in subframes
+  (except the Disqus embed) for less overhead.
+- **Engine rewrite:** uniform sites fold into one data-driven table; the
+  per-site cleaners and redirect decoders are now unit-tested under CI
+  (Node's built-in test runner).
+- **Removed:** Twitter and Pocket handling (sites changed; cleaning no
+  longer applied).
+
 ## What it does
 
 The script runs on each supported site and:

--- a/greasyfork-description.md
+++ b/greasyfork-description.md
@@ -7,6 +7,17 @@ The full README (with dev/test/contributing info) lives on GitHub.
 Strips tracking and redirect parameters from URLs on shopping, search, and
 social sites — both the address in your browser bar and the links on the page.
 
+**New in 5.0**
+
+- Added support for Bing, Audible, LinkedIn, Etsy, Yahoo, Spotify, Reddit,
+  Twitch, Threads, AliExpress, Walmart, Best Buy, and TikTok.
+- `utm_*` and common click-ID params are now stripped on *every* site, not
+  just ones with a dedicated handler.
+- Cleaning fixes for Google, eBay, Amazon, Disqus, and Facebook, plus a
+  trailing-ampersand bug.
+- Link cleaning now follows in-page (single-page-app) navigation.
+- Removed Twitter and Pocket handling.
+
 **What it does**
 
 - Cleans the current page URL, dropping tracking params (`utm_*`, click IDs,


### PR DESCRIPTION
## Summary
- Add a `What's new in 5.0` section to README.md (site additions, global tracking-param stripping, cleaning fixes, SPA-aware link cleaning, engine rewrite, Twitter/Pocket removals).
- Add a trimmed `New in 5.0` block to greasyfork-description.md for the listing.

## Test plan
- [ ] README renders on GitHub; 5.0 list matches merged-PR history
- [ ] greasyfork-description.md renders as Markdown when pasted into GreasyFork

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
