### PR TITLE
fix: scope to supported sites only and fix Amazon order-details links

### DIFF
--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -3,7 +3,7 @@
 // @namespace   https://greasyfork.org/en/users/594496-divided-by
 // @author      dividedby
 // @description Cleans URLs from various popular sites and removes tracking parameters
-// @version     5.0.0
+// @version     5.0.1
 // @license     GPL version 3 or any later version; http://www.gnu.org/copyleft/gpl.html
 // @contributionURL     https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=dividedbygit@gmail.com&item_name=Greasy+Fork+Donation
 // @contributionAmount  $1
@@ -40,7 +40,6 @@
 // @include     https://www.tiktok.com/*
 // @include     https://tiktok.com/*
 // @include     https://vm.tiktok.com/*
-// @include     *
 // @exclude     /^https:\/\/[a-z0-9.]*\.?amazon(\.[a-z0-9]{2,3})?(\.[a-z]+)?\/(?:gp\/(?:cart|buy|css|legacy|your-account).*|sspa.*)$/
 // @exclude     https://apis.google.com/*
 // @exclude     https://accounts.google.com/*
@@ -659,7 +658,11 @@
       t.search = "";
       result = t.href;
     } else if (u.search) {
-      result = cleanAmazonParams(href);
+      // clean only the query, not the whole href: amazonParams' [^&#]* value
+      // would otherwise swallow the ? separator when the path contains a ref=
+      // segment, collapsing the query into the path (breaks order-details).
+      u.search = cleanAmazonParams(u.search);
+      result = u.href;
     }
 
     var u2 = new URL(result);

--- a/test/cleaners.test.js
+++ b/test/cleaners.test.js
@@ -17,6 +17,7 @@ const {
   cleanGlobalParams,
   cleanYoutubeRedir,
   cleanAmazonRedir,
+  transformAmazonUrl,
   cleanGenericRedir,
   cleanParams,
   bingParams,
@@ -160,6 +161,24 @@ describe("cleanAmazonParams", () => {
 
   it("removes trailing ? when all params are stripped", () => {
     assert.equal(cleanAmazonParams("?ref=sr_1_1"), "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformAmazonUrl
+// Regression: an order-details link has a ref= segment in the PATH and a
+// functional query (orderID). Cleaning the whole href let amazonParams' value
+// match swallow the ? separator, collapsing the query into the path and
+// breaking the page. Only the query should be cleaned.
+// ---------------------------------------------------------------------------
+describe("transformAmazonUrl", () => {
+  it("preserves orderID query on order-details links with a ref= path segment", () => {
+    assert.equal(
+      transformAmazonUrl(
+        "https://www.amazon.com/gp/your-account/order-details/ref=dp_iou_view_this_order?ie=UTF8&orderID=123-4567890-1234567"
+      ),
+      "https://www.amazon.com/gp/your-account/order-details/?orderID=123-4567890-1234567"
+    );
   });
 });
 


### PR DESCRIPTION
Fixes two issues reported in the [GreasyFork discussion](https://greasyfork.org/en/scripts/432387-general-url-cleaner-revived/discussions/260683).

## Scope back to supported sites
Removed the `// @include *` directive. The script was running on every website, breaking unrelated sites (e.g. Jellyfin's sidebar). It now loads only on the explicitly listed `@include` hosts.

## Amazon order-details / View Order links
`transformAmazonUrl` passed the entire `href` to `cleanAmazonParams`. The param regex's value match (`[^&#]*`) swallowed the `?` separator when the path contained a `ref=` segment, collapsing the query into the path:

- before: `.../order-details/ref=…?ie=UTF8&orderID=123` → `.../order-details/orderID=123` (query destroyed, page breaks)
- after: cleans only `u.search` → `.../order-details/?orderID=123` (preserved)

Added a regression test covering the order-details case. Bumped version to 5.0.1.

Test suite: 246 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
