### PR TITLE
docs: reflect 5.0.1 scope change in README and GreasyFork listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@ in your browser bar and the links on the page.
 - **Issues / PRs:** [GitHub](https://github.com/dividedby/General-URL-Cleaner-Revived)
 - **Forked from** [beck's General URL Cleaner](https://greasyfork.org/en/scripts/395298-general-url-cleaner).
 
-## What's new in 5.0
+## What's new
+
+### 5.0.1
+
+- **Scoped to supported sites only:** the script now runs only on the sites
+  listed below. 5.0 ran on *every* website, which could interfere with
+  unrelated pages.
+- **Amazon order pages fixed:** "View Order" / order-details links keep their
+  `orderID` query intact instead of having it mangled.
+
+### 5.0
 
 A major release built up across many fixes, new site coverage, and an
 engine rewrite.
 
 - **New site support:** Bing, Audible, LinkedIn, Etsy, Yahoo, Spotify,
   Reddit, Twitch, Threads, AliExpress, Walmart, Best Buy, and TikTok.
-- **Global tracking-param stripping:** `utm_*` and common click-ID
-  parameters are now removed on *every* site, not just ones with a dedicated
-  handler (opt-out via the `GLOBAL_STRIP` flag).
 - **Cleaning fixes:** Google (`sclient`/`ping`/`authuser`), eBay, Amazon
   (`/dp/` and `/gp/product/`), Disqus, Facebook, and a long-standing
   trailing-ampersand bug.
@@ -32,7 +39,7 @@ engine rewrite.
 
 ## What it does
 
-The script runs on each supported site and:
+The script runs only on the supported sites listed below and:
 
 - Rewrites the current page URL via `history.replaceState()` to drop tracking
   params (e.g. `utm_*`, click IDs, session tokens).
@@ -52,8 +59,7 @@ Dedicated handlers: **Google**, **Bing**, **YouTube**, **Amazon**, **eBay**,
 **LinkedIn**, **Etsy**, **Yahoo**, **Spotify**, **Reddit**, **Twitch**,
 **Threads**, **AliExpress**, **Walmart**, **Best Buy**, **TikTok**.
 
-On every other site, the script still strips `utm_*` and common generic
-tracking parameters.
+The script does not run on any other site.
 
 ### Examples
 

--- a/greasyfork-description.md
+++ b/greasyfork-description.md
@@ -7,12 +7,17 @@ The full README (with dev/test/contributing info) lives on GitHub.
 Strips tracking and redirect parameters from URLs on shopping, search, and
 social sites — both the address in your browser bar and the links on the page.
 
+**New in 5.0.1**
+
+- Scoped back to the supported sites only — 5.0 ran on *every* website, which
+  could interfere with unrelated pages.
+- Fixed Amazon "View Order" / order-details links so the `orderID` query
+  stays intact.
+
 **New in 5.0**
 
 - Added support for Bing, Audible, LinkedIn, Etsy, Yahoo, Spotify, Reddit,
   Twitch, Threads, AliExpress, Walmart, Best Buy, and TikTok.
-- `utm_*` and common click-ID params are now stripped on *every* site, not
-  just ones with a dedicated handler.
 - Cleaning fixes for Google, eBay, Amazon, Disqus, and Facebook, plus a
   trailing-ampersand bug.
 - Link cleaning now follows in-page (single-page-app) navigation.
@@ -33,8 +38,8 @@ etc.) that break when cleaned.
 
 Dedicated handlers for Google, Bing, YouTube, Amazon, eBay, Newegg, Target,
 Facebook, IMDB, Disqus, Audible, LinkedIn, Etsy, Yahoo, Spotify, Reddit,
-Twitch, Threads, AliExpress, Walmart, Best Buy, and TikTok. On every other
-site, it still strips `utm_*` and common generic tracking parameters.
+Twitch, Threads, AliExpress, Walmart, Best Buy, and TikTok. The script does
+not run on any other site.
 
 **Examples**
 


### PR DESCRIPTION
## Summary
- Docs were claiming the script strips trackers on *every* site; 5.0.1 removed that global behavior. Update README and the GreasyFork listing to state it runs only on the supported sites.
- Add 5.0.1 release notes (scope fix + Amazon order-details fix) to both docs.

## Test plan
- [x] README and greasyfork-description.md no longer claim every-site / generic stripping
- [x] 5.0.1 notes present in both
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
