### PR TITLE
feat: strip utm_/click-ID params on supported sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ in your browser bar and the links on the page.
   unrelated pages.
 - **Amazon order pages fixed:** "View Order" / order-details links keep their
   `orderID` query intact instead of having it mangled.
+- **Generic trackers stripped everywhere:** `utm_*` and common click-ID
+  parameters (`gclid`, `fbclid`, `msclkid`, etc.) are now removed on all
+  supported sites — both the page URL and the links — not just the few that
+  routed through the generic cleaner before.
 
 ### 5.0
 

--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -166,7 +166,7 @@
         setCurrUrl(cleanNewegg(currSearch));
       }
 
-      cleanLinks(parserNewegg);
+      cleanLinks(parserAll);
       return;
     }
 
@@ -175,7 +175,7 @@
         setCurrUrl(cleanImdb(currSearch));
       }
 
-      cleanLinks(parserIMDB);
+      cleanLinks(parserAll);
       onhashchange = deleteHash;
       return;
     }
@@ -208,7 +208,7 @@
         setCurrUrl(cleanEbayParams(currSearch));
       }
 
-      cleanLinks(parserEbay);
+      cleanLinks(parserAll);
       onhashchange = deleteHash;
       return;
     }
@@ -234,7 +234,7 @@
         setCurrUrl(cleanAmazonParams(currSearch));
       }
 
-      cleanLinks(parserAmazon);
+      cleanLinks(parserAll);
       onhashchange = deleteHash;
       return;
     }
@@ -280,7 +280,7 @@
    */
 
   function setCurrUrl(url) {
-    history.replaceState(null, null, url);
+    history.replaceState(null, null, cleanUtm(url));
   }
 
   function deleteHash() {
@@ -441,11 +441,11 @@
   }
 
   function parserTarget(a) {
-    if (!target.test(a.host)) {
-      return;
+    if (target.test(a.host)) {
+      a.href = transformTargetUrl(a.href);
     }
 
-    a.href = transformTargetUrl(a.href);
+    a.href = transformGlobalUrl(a.href);
   }
 
   function parserAmazon(a) {
@@ -484,13 +484,13 @@
   }
 
   function parserFacebook(a) {
-    if (a.host !== "l.facebook.com" || a.pathname !== "/l.php") {
-      return;
+    if (a.host === "l.facebook.com" && a.pathname === "/l.php") {
+      a.href = transformFacebookUrl(a.href);
+      a.removeAttribute("onclick");
+      a.removeAttribute("onmouseover");
     }
 
-    a.href = transformFacebookUrl(a.href);
-    a.removeAttribute("onclick");
-    a.removeAttribute("onmouseover");
+    a.href = transformGlobalUrl(a.href);
   }
 
   function parserDisqus(a) {

--- a/URLClean.user.js
+++ b/URLClean.user.js
@@ -280,7 +280,7 @@
    */
 
   function setCurrUrl(url) {
-    history.replaceState(null, null, cleanUtm(url));
+    history.replaceState(null, null, cleanGlobalParams(cleanUtm(url)));
   }
 
   function deleteHash() {

--- a/greasyfork-description.md
+++ b/greasyfork-description.md
@@ -13,6 +13,8 @@ social sites — both the address in your browser bar and the links on the page.
   could interfere with unrelated pages.
 - Fixed Amazon "View Order" / order-details links so the `orderID` query
   stays intact.
+- `utm_*` and common click-ID params (`gclid`, `fbclid`, `msclkid`, …) are now
+  stripped on all supported sites — both the page URL and the links.
 
 **New in 5.0**
 


### PR DESCRIPTION
## Summary
- Strip `utm_*` and curated click-ID params (`gclid`, `fbclid`, `msclkid`, …) on all supported sites — previously only the global fallback did this, which supported-site handlers never reached.
- `setCurrUrl` runs `cleanUtm`, covering every supported site's address bar.
- Amazon/eBay/Newegg/IMDB link dispatch routes through `parserAll` (already appends `transformGlobalUrl`) — no redundant work. Target/Facebook parsers append `transformGlobalUrl` directly (not part of `parserAll`).
- Docs: 5.0.1 notes updated in README and the GreasyFork listing.

## Test plan
- [x] `node --test` — 246 pass / 0 fail
- DOM link/address-bar paths are manual-test per repo convention (ADR 0001 test seam at the pure transforms; `transformGlobalUrl`/`cleanUtm` already unit-tested)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
