### PR TITLE
ci: Node 20->22 (EOL), checkout/setup-node to v6, add concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,16 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
       - run: node --test


### PR DESCRIPTION
Part of the estate-wide CI hygiene sweep from the non-vendored workflow audit — see `dividedby/skills#378` for the full audit and the deferred items. Change specifics are in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
