### PR TITLE
docs(labels): sync LOCAL fourth-tier clarification from canonical

### DIFF
--- a/docs/agents/labels.md
+++ b/docs/agents/labels.md
@@ -11,9 +11,9 @@ Labels fall into four tiers plus a remove-stock rule.
 - **LOOP/NETWORK** — only repos that run the proposal loops (full-tier repos).
 - **CHANNELS** — owned by `dividedby/skills`; consumer repos *apply* them but never
   create them.
+- **LOCAL** — domain one-off labels; private to a repo, untouched by the convention.
 
-Domain one-off labels stay **local** and untouched. The convention governs the
-shared vocabulary, not a repo's private labels.
+The convention governs the shared vocabulary, not a repo's private labels.
 
 ## CORE — State (all repos)
 


### PR DESCRIPTION
## Summary

- Propagate `dividedby/skills#392`: make `LOCAL` an explicit fourth-tier bullet in the label convention's `## Tiering rule`, so "four tiers" matches what's enumerated (it previously bulleted three with LOCAL in prose). No semantic change — LOCAL one-offs were always ungoverned by the convention.

## Test plan

- [ ] Docs-only; byte-identical propagation of the merged canonical change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
